### PR TITLE
Feat: Context Initialization pre-stage seeds a Research Frame

### DIFF
--- a/CoScientist/agents/prompts/templates.py
+++ b/CoScientist/agents/prompts/templates.py
@@ -1270,9 +1270,17 @@ def orchestrator(ctx: PromptContext) -> str:
             "state and active triggers:\n"
             "{research_context?}\n\n"
             "Protocol (for research investigations):\n"
-            "- EMPTY graph + a research task ⇒ call `research_init(question=…)` "
-            "first (include known tools / resources / constraints / empirical "
-            "bases), then delegate.\n"
+            "- The context-initialization pre-stage normally SEEDS the graph "
+            "(root question + framing frame) before you run. Only if the graph is "
+            "still EMPTY, call `research_init(question=…)` first (include known "
+            "tools / resources / constraints / empirical bases), then delegate.\n"
+            "- FRAME GATE (experiment setup): before you start a COSTLY "
+            "VerificationMethod (one that consumes Resources), the frame must be "
+            "set — the question must carry a completion_criteria attribute AND the "
+            "graph must hold ConfirmationCriteria and a CostModel. If they are "
+            "missing, prefer cheap literature evidence first, or (HITL on) ask the "
+            "operator; do NOT launch an expensive experiment on an unframed "
+            "research.\n"
             "- Consult `research_triggers` before each step and act on them:\n"
             "  • READY hypothesis (tools available) ⇒ verify it in this ORDER: "
             "call `research_set_focus(<hypothesis id>)` FIRST, THEN delegate the "
@@ -1690,6 +1698,77 @@ Output the complete Markdown report as your final message.
 # ═════════════════════════════════════════════════════════════════════════════
 
 # ── TZSpecAgent — free-form request -> StructuredTZ (document-shaped) ────────
+
+@_register("context_init")
+def context_init(ctx: PromptContext) -> str:
+    """Draft the ResearchFrame — the framing entities of the meta-model."""
+    from CoScientist.context_init.models import FRAME_SPEC
+
+    block_lines = []
+    for i, (title, kind, subtype, usage, field_names) in enumerate(FRAME_SPEC, 1):
+        block_lines.append(
+            f"{i}. «{title}» ({usage}). Поля: {', '.join(field_names)}.")
+    blocks_desc = "\n".join(block_lines)
+
+    return render_template('''
+Ты — агент инициализации контекста в системе CoScientist (мультиагентная
+система для научно-исследовательского процесса). Твоя задача — превратить
+исследовательский вопрос пользователя (последнее сообщение) в СТРУКТУРИРОВАННУЮ
+РАМКУ ИССЛЕДОВАНИЯ: набор блоков, где каждый блок — группа полей, и каждое поле
+имеет значение и статус. Из этого JSON заполняется контекст графа исследования
+ДО того, как оркестратор выберет стратегию (литературный обзор, дорогой или
+дешёвый эксперимент). Поэтому рамка важна.
+
+ОБЯЗАТЕЛЬНЫЕ БЛОКИ (ровно с такими названиями и полями, в этом порядке):
+<<BLOCKS_DESC>>
+
+ПРАВИЛА:
+- Заполни поле «formulation» блока «Вопрос исследования» точной формулировкой
+  вопроса пользователя.
+- Не выдумывай факты. Если значения нет ни в запросе, ни в разумном контексте
+  домена — оставь value «Не задано», status «не задано» (такие поля ОБЯЗАТЕЛЬНО
+  оставляй — они показывают пробелы, которые заполнит оператор).
+- Значения, прямо названные пользователем, помечай статусом «задано заказчиком».
+- Обоснованные рабочие значения из контекста домена помечай статусом
+  «уточнено оператором».
+- Значения, которые определятся на следующих этапах (напр. фактические
+  бюджеты), помечай статусом «рассчитывается агентом».
+- Для блока «Режим и завершение»: ai_application_model — один из
+  «ИИ-лаборант / ИИ-ассистент / ИИ-копайлот / ИИ-архитектор»;
+  completion_criteria — один из «исчерпывающий / прагматичный / ресурсный /
+  экономический».
+- Для «Ресурсы и бюджеты» значение задавай как «остаток / лимит» (напр.
+  «100 / 100») там, где это применимо.
+- В каждом блоке заполни usage — одну фразу, как блок используется дальше.
+- Поле original_request заполни исходным запросом пользователя дословно.
+- Отвечай ТОЛЬКО валидным JSON без пояснений и без обрамления ```.
+
+ОБРАБОТКА ОТВЕТОВ ОПЕРАТОРА (при перегенерации после ревью):
+Если фидбек содержит правки — примени их к полям, статус «уточнено оператором».
+Всегда возвращай ПОЛНЫЙ обновлённый JSON рамки (все блоки).
+
+Статусы поля (строго одно из): "задано заказчиком", "уточнено оператором",
+"не задано", "свободный комментарий", "рассчитывается агентом".
+
+ФОРМАТ ОТВЕТА (строго этот JSON; показан один блок для примера — заполни ВСЕ
+обязательные блоки и их поля):
+{
+  "original_request": "<исходный запрос пользователя дословно>",
+  "blocks": [
+    {
+      "title": "Вопрос исследования",
+      "kind": "question",
+      "usage": "атрибуты корневого исследовательского вопроса",
+      "fields": [
+        {"name": "formulation", "value": "...", "status": "задано заказчиком"},
+        {"name": "domain", "value": "...", "status": "уточнено оператором"},
+        {"name": "trl", "value": "Не задано", "status": "не задано"}
+      ]
+    }
+  ]
+}
+''', BLOCKS_DESC=blocks_desc)
+
 
 @_register("microfluidics_tz")
 def microfluidics_tz(ctx: PromptContext) -> str:

--- a/CoScientist/agents/system.yaml
+++ b/CoScientist/agents/system.yaml
@@ -49,7 +49,7 @@ defaults:
 # The manager driver (CoScientist.main) executes: pre… → root → post…
 # ─────────────────────────────────────────────────────────────────────────────
 pipeline:
-  pre: []                         # e.g. [PlannerAgent] to A/B-test the planner
+  pre: [ContextInitAgent]         # draft + confirm + seed the research frame
   post: [ResultAggregatorAgent]
 
 agents:
@@ -129,6 +129,29 @@ agents:
         name: Plan
         description: Produce a research roadmap for a scientific task
         tags: [planning, roadmap, science]
+
+  # ── Context initialization (pre-stage) ──────────────────────────────────────
+  ContextInitAgent:
+    # context_init_session = SessionAgent whose review shows the operator a
+    # STRUCTURED FORM of the research frame (the framing entities of the
+    # meta-model). Once confirmed, it seeds the frame into the Research Context
+    # Graph (root question + constraint star + budgets + tools + empirical base +
+    # confirmation criteria + cost model) BEFORE the orchestrator picks a
+    # strategy. Runs as pipeline.pre; toggle via ${context_init.enabled}.
+    class: custom:context_init_session
+    enabled: ${context_init.enabled}
+    description: >-
+      агент инициализации контекста — превращает исследовательский вопрос в
+      структурированную рамку (вопрос, профиль, ограничения, бюджеты,
+      инструменты, эмпирическая база, условия подтверждения, модель стоимости),
+      согласует её с оператором и заполняет граф исследования до старта.
+    prompt: context_init
+    output_key: research_frame
+    output_schema: research_frame
+    hitl: true
+    callbacks:
+      # Strip prose/fences around the JSON before strict output_schema validation.
+      after_model: [sanitize_json_output]
 
   ResultAggregatorAgent:
     class: llm

--- a/CoScientist/assembly/bindings.py
+++ b/CoScientist/assembly/bindings.py
@@ -750,16 +750,21 @@ def _register_classes() -> None:
     from CoScientist.agents.custom_agents import WebToolsDeployerAgent
     from CoScientist.hitl.session_agent import SessionAgent
     from CoScientist.microfluidics.tz_agent import TZSessionAgent
+    from CoScientist.context_init.agent import ContextInitSessionAgent
 
     REGISTRY.register_agent_class("session", SessionAgent)
     REGISTRY.register_agent_class("web_tools_deployer", WebToolsDeployerAgent)
     # Microfluidics ТЗ stage: the review loop shows the RENDERED ТЗ document.
     REGISTRY.register_agent_class("tz_session", TZSessionAgent)
+    # Context-init pre-stage: the review shows a STRUCTURED FORM (research frame)
+    # and seeds the confirmed frame into the research graph.
+    REGISTRY.register_agent_class("context_init_session", ContextInitSessionAgent)
 
 
 def _register_schemas() -> None:
     from CoScientist.storage import MCPRanking, ToolRanking
     from CoScientist.microfluidics.models import LiteratureQueries, StructuredTZ
+    from CoScientist.context_init.models import ResearchFrame
 
     REGISTRY.register_output_schema("tool_ranking", ToolRanking)
     REGISTRY.register_output_schema("mcp_ranking", MCPRanking)
@@ -767,6 +772,8 @@ def _register_schemas() -> None:
     # from it (see CoScientist/agents/microfluidics.yaml).
     REGISTRY.register_output_schema("structured_tz", StructuredTZ)
     REGISTRY.register_output_schema("tz_literature_queries", LiteratureQueries)
+    # Framing entities of the meta-model, filled per run (context_init pre-stage).
+    REGISTRY.register_output_schema("research_frame", ResearchFrame)
 
 
 def _register_planners() -> None:

--- a/CoScientist/config/settings.py
+++ b/CoScientist/config/settings.py
@@ -162,6 +162,22 @@ class HITLSettings(BaseModel):
     enabled: bool = False
 
 # =========================
+# CONTEXT INITIALIZATION
+# =========================
+class ContextInitSettings(BaseModel):
+    """The pre-stage that drafts the research frame, confirms it with the
+    operator (structured web form, when HITL is on) and seeds it into the
+    research graph before the orchestrator runs.
+
+    ``enabled`` gates the whole pre-stage — referenced from system.yaml as
+    ``${context_init.enabled}``. The gate is soft: the operator may submit the
+    form with fields deferred (the agent fills working values), so a run never
+    blocks indefinitely. Override via CONTEXT_INIT__ENABLED.
+    """
+    enabled: bool = True
+
+
+# =========================
 # ORCHESTRATOR
 # =========================
 class OrchestratorSettings(BaseModel):
@@ -254,6 +270,7 @@ class Settings(BaseSettings):
     s3: S3Settings = S3Settings()
     opik: OpikSettings = OpikSettings()
     hitl: HITLSettings = HITLSettings()
+    context_init: ContextInitSettings = ContextInitSettings()
     orchestrator: OrchestratorSettings = OrchestratorSettings()
     code_exec: CodeExecSettings = CodeExecSettings()
     tool_rag: ToolRAGSettings = ToolRAGSettings()

--- a/CoScientist/context_init/__init__.py
+++ b/CoScientist/context_init/__init__.py
@@ -1,0 +1,8 @@
+"""Context initialization: draft, confirm (HITL), and seed the research frame.
+
+The 6-layer scientific meta-model is already the schema of the Research Context
+Graph (``graph/research/``). This package fills its FRAMING entities on each run:
+a pre-stage agent drafts a structured ``ResearchFrame`` from the raw question,
+the operator confirms/edits it through a structured web form, and the confirmed
+frame is seeded into the graph BEFORE the orchestrator picks a research strategy.
+"""

--- a/CoScientist/context_init/agent.py
+++ b/CoScientist/context_init/agent.py
@@ -1,0 +1,170 @@
+"""The pre-stage context-initialization agent.
+
+``ContextInitSessionAgent`` is a ``SessionAgent`` that:
+
+  1. runs its LLM to draft a ``ResearchFrame`` from the raw research question
+     (``output_schema = research_frame``, stored under ``output_key``);
+  2. shows the operator a STRUCTURED WEB FORM (one field per framing entity)
+     through the HITL bridge, and folds the operator's answers back onto the
+     frame — untouched fields keep the agent's drafted values (soft gate);
+  3. seeds the confirmed frame into the Research Context Graph (the privileged
+     init path) BEFORE the orchestrator runs, then publishes a short summary.
+
+In headless mode (no HITL handler) the base loop skips the review and step 3
+still runs — the agent's drafted frame is seeded as-is.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Dict, List, Optional
+
+from google.adk.agents.invocation_context import InvocationContext
+from google.adk.events.event import Event
+from google.adk.events.event_actions import EventActions
+from google.genai import types
+
+from CoScientist.context_init.commit import seed_frame
+from CoScientist.context_init.models import ResearchFrame
+from CoScientist.graph.research.store import get_research_graph
+from CoScientist.graph.session_scope import session_key
+from CoScientist.hitl.field_status import OPERATOR_STATUS, is_open
+from CoScientist.hitl.models import HITLAction, HITLRequest, HITLResponse
+from CoScientist.hitl.session_agent import SessionAgent
+
+logger = logging.getLogger(__name__)
+
+FRAME_STATE_KEY = "research_frame"
+_FORM_INTRO = ("Заполните рамку исследования. Пустые поля агент заполнит "
+               "рабочими значениями. Рамка задаёт стратегию: литературный "
+               "поиск, дорогой или дешёвый эксперимент.")
+
+
+def coerce_frame(value: Any) -> ResearchFrame:
+    """Best-effort ResearchFrame from a model output / state value."""
+    if isinstance(value, ResearchFrame):
+        return value.normalized()
+    if isinstance(value, str):
+        value = json.loads(value)
+    return ResearchFrame.model_validate(value).normalized()
+
+
+def frame_to_form(frame: ResearchFrame) -> Dict[str, Any]:
+    """Build the HITLRequest.form payload the web UI renders as a form."""
+    frame = frame.normalized()
+    blocks: List[Dict[str, Any]] = []
+    for b in frame.blocks:
+        fields = [
+            {"name": f.name, "value": f.value, "status": f.status,
+             "open": is_open(f.status)}
+            for f in b.fields
+        ]
+        blocks.append({"title": b.title, "usage": b.usage, "fields": fields})
+    return {"title": "Рамка исследования", "intro": _FORM_INTRO, "blocks": blocks}
+
+
+def apply_form_values(frame: ResearchFrame,
+                      form_values: Optional[Dict[str, Any]]) -> ResearchFrame:
+    """Fold operator answers ({block: {field: value}}) onto the frame; the
+    touched fields become «уточнено оператором», the rest keep their status."""
+    if not form_values:
+        return frame
+    frame = frame.normalized()
+    for b in frame.blocks:
+        answers = form_values.get(b.title) or {}
+        if not isinstance(answers, dict):
+            continue
+        for f in b.fields:
+            val = answers.get(f.name)
+            if val is None or not str(val).strip():
+                continue
+            f.value = str(val).strip()
+            f.status = OPERATOR_STATUS
+    return frame
+
+
+def render_frame_summary(frame: ResearchFrame) -> str:
+    """Compact readable summary (console review / chat publication)."""
+    lines: List[str] = ["## Рамка исследования", ""]
+    for b in frame.blocks:
+        set_fields = b.set_fields()
+        mark = "✓" if set_fields else "—"
+        lines.append(f"{mark} **{b.title}**"
+                     + (f": {len(set_fields)} поле(й)" if set_fields else " (пусто)"))
+        for f in set_fields:
+            lines.append(f"    - {f.name}: {f.value}")
+    return "\n".join(lines)
+
+
+class ContextInitSessionAgent(SessionAgent):
+    """SessionAgent that confirms the frame via a web form and seeds the graph."""
+
+    def _review_output(self, output_text) -> str:
+        try:
+            return render_frame_summary(coerce_frame(output_text))
+        except Exception:  # noqa: BLE001 — review must never crash the run
+            return super()._review_output(output_text)
+
+    async def _review_decision(self, ctx: InvocationContext, output_text) -> HITLResponse:
+        try:
+            frame = coerce_frame(ctx.session.state.get(self.output_key) or output_text)
+        except Exception as exc:  # noqa: BLE001 — fall back to plain approval
+            logger.warning("frame form skipped (parse failed): %s", exc)
+            return HITLResponse(action=HITLAction.APPROVE, approved=True)
+
+        user_id, session_id = session_key(ctx)
+        request = HITLRequest(
+            agent_name=self.name,
+            action_type=HITLAction.APPROVE,
+            message="Подтвердите рамку исследования перед запуском.",
+            form=frame_to_form(frame),
+            context={"_session": {"user_id": user_id, "session_id": session_id}},
+            invoked_via="internal_loop",
+        )
+        response = await self.hitl_handler.handle_request(request)
+
+        # Fold the operator's answers in and store the merged frame back, so the
+        # base loop finishes (approved, no instructions) with the updated frame.
+        merged = apply_form_values(frame, response.form_values)
+        if self.output_key:
+            ctx.session.state[self.output_key] = merged.model_dump()
+        return HITLResponse(action=HITLAction.APPROVE, approved=True)
+
+    def _post_final_events(self, ctx: InvocationContext, output_text):
+        try:
+            frame = coerce_frame(ctx.session.state.get(self.output_key) or output_text)
+        except Exception as exc:  # noqa: BLE001 — seeding must not kill the run
+            logger.warning("frame not seeded (parse failed): %s", exc)
+            return
+        try:
+            store = get_research_graph(ctx)
+            result = seed_frame(store, frame)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("frame graph seeding failed: %s", exc)
+            return
+
+        ok = bool(result.get("ok"))
+        stats = result.get("graph_stats") or {}
+        header = ("🧭 Рамка исследования зафиксирована в графе"
+                  if ok else "⚠️ Рамку не удалось зафиксировать в графе")
+        if ok and stats:
+            header += (f" ({stats.get('nodes', 0)} узлов, "
+                       f"{stats.get('edges', 0)} рёбер).")
+        text = f"{header}\n\n{render_frame_summary(frame)}"
+        yield Event(
+            invocation_id=ctx.invocation_id,
+            author=self.name,
+            branch=ctx.branch,
+            content=types.Content(role="model", parts=[types.Part(text=text)]),
+            actions=EventActions(state_delta={FRAME_STATE_KEY: frame.model_dump()}),
+        )
+
+
+__all__ = [
+    "ContextInitSessionAgent",
+    "FRAME_STATE_KEY",
+    "apply_form_values",
+    "coerce_frame",
+    "frame_to_form",
+    "render_frame_summary",
+]

--- a/CoScientist/context_init/commit.py
+++ b/CoScientist/context_init/commit.py
@@ -1,0 +1,157 @@
+"""Seed a confirmed ``ResearchFrame`` into the Research Context Graph.
+
+Maps the frame's blocks onto ``store.init_research`` (the privileged seeding
+path): the question block becomes the root ResearchQuestion's attributes; the
+constraint blocks become the Constraint context star; budgets/tools/empirical
+base become their nodes; the criteria and cost-model blocks become
+ConfirmationCriteria and CostModel. Each node is attributed to ``human`` when
+its value came from the operator or the user's request, else to
+``ContextInitAgent`` — so the graph records the automation-vs-human split.
+"""
+from __future__ import annotations
+
+import re
+from typing import Any, Dict, List, Optional
+
+from CoScientist.context_init.models import FrameBlock, ResearchFrame
+
+AGENT_SOURCE = "ContextInitAgent"
+HUMAN_SOURCE = "human"
+# Statuses that mean a human supplied the value (operator form or user request).
+_HUMAN_STATUSES = ("уточнено оператором", "задано заказчиком")
+
+# Frame field name -> EmpiricalBase.base_type.
+_EB_TYPE = {"datasets": "dataset", "corpora": "corpus", "trusted_kb": "knowledge_base"}
+_REMAINING_LIMIT = re.compile(r"^\s*([\d.]+)\s*/\s*([\d.]+)\s*$")
+
+
+def _block_source(block: FrameBlock) -> str:
+    """`human` when any set field of the block came from a human, else agent."""
+    for f in block.set_fields():
+        if f.status in _HUMAN_STATUSES:
+            return HUMAN_SOURCE
+    return AGENT_SOURCE
+
+
+def _content(block: FrameBlock) -> str:
+    """Join a block's set fields into one readable content string."""
+    return "; ".join(f"{f.name}: {f.value}".strip() for f in block.set_fields())
+
+
+def frame_to_init_kwargs(frame: ResearchFrame) -> Dict[str, Any]:
+    """Translate a (normalized) frame into ``store.init_research`` keyword args."""
+    frame = frame.normalized()
+    question_attrs: Dict[str, str] = {}
+    question_source: Optional[str] = None
+    constraints: List[Dict[str, Any]] = []
+    tools: List[Dict[str, Any]] = []
+    resources: List[Dict[str, Any]] = []
+    empirical_bases: List[Dict[str, Any]] = []
+    confirmation_criteria: List[Dict[str, Any]] = []
+    cost_models: List[Dict[str, Any]] = []
+
+    for block in frame.blocks:
+        set_fields = block.set_fields()
+        if not set_fields and block.kind != "question":
+            continue
+        src = _block_source(block)
+
+        if block.kind == "question":
+            for f in set_fields:
+                if f.name == "formulation":
+                    continue  # the root formulation is passed separately
+                question_attrs[f.name] = f.value
+                if f.status in _HUMAN_STATUSES:
+                    question_source = HUMAN_SOURCE
+            question_source = question_source or (
+                HUMAN_SOURCE if src == HUMAN_SOURCE else question_source)
+
+        elif block.kind == "constraint":
+            constraints.append({"subtype": block.subtype, "content": _content(block),
+                                "source": src})
+
+        elif block.kind == "resources":
+            for f in set_fields:
+                attrs: Dict[str, Any] = {"resource_type": f.name}
+                m = _REMAINING_LIMIT.match(f.value)
+                if m:
+                    attrs["remaining"], attrs["limit"] = m.group(1), m.group(2)
+                else:
+                    attrs["note"] = f.value
+                resources.append({"attrs": attrs, "source": src})
+
+        elif block.kind == "tools":
+            for f in set_fields:
+                tools.append({"attrs": {"name": f.value, "tool_type": f.name},
+                              "status": "available", "source": src})
+
+        elif block.kind == "empirical_base":
+            for f in set_fields:
+                empirical_bases.append({
+                    "attrs": {"base_type": _EB_TYPE.get(f.name, f.name),
+                              "source_ref": f.value},
+                    "source": src})
+
+        elif block.kind == "confirmation_criteria":
+            confirmation_criteria.append({
+                "attrs": {f.name: f.value for f in set_fields}, "source": src})
+
+        elif block.kind == "cost_model":
+            attrs = {f.name: f.value for f in set_fields}
+            if attrs:
+                # CostModel's documented attr is `rule`; fold the cost rule there.
+                attrs.setdefault("rule", attrs.get("cost_rule", ""))
+                cost_models.append({"attrs": attrs, "source": src})
+
+    q_block = frame.block("Вопрос исследования")
+    formulation = ""
+    if q_block is not None:
+        for f in q_block.fields:
+            if f.name == "formulation" and f.is_set():
+                formulation = f.value
+                break
+    question = formulation or frame.original_request
+
+    return {
+        "question": question,
+        "attrs": question_attrs,
+        "question_source": question_source,
+        "constraints": constraints,
+        "tools": tools,
+        "resources": resources,
+        "empirical_bases": empirical_bases,
+        "confirmation_criteria": confirmation_criteria,
+        "cost_models": cost_models,
+    }
+
+
+def _dump_frame(store, frame: ResearchFrame, result: Dict[str, Any]) -> None:
+    """Persist the confirmed frame next to the graph, for durable per-field
+    provenance. The graph node ``source`` is coarse (block-level), so the frame's
+    per-field status is the audit record of who supplied each piece."""
+    directory = getattr(store, "_dir", None)
+    if directory is None:
+        return
+    try:
+        import json
+        from pathlib import Path
+
+        Path(directory).mkdir(parents=True, exist_ok=True)
+        payload = {"root_id": result.get("root_id"),
+                   "frame": frame.normalized().model_dump()}
+        (Path(directory) / "research_frame.json").write_text(
+            json.dumps(payload, ensure_ascii=False, indent=1), encoding="utf-8")
+    except OSError:
+        pass  # a failed sidecar dump must never break seeding
+
+
+def seed_frame(store, frame: ResearchFrame) -> Dict[str, Any]:
+    """Seed the confirmed frame into ``store`` (a ResearchGraphStore)."""
+    kwargs = frame_to_init_kwargs(frame)
+    result = store.init_research(source=AGENT_SOURCE, **kwargs)
+    if result.get("ok"):
+        _dump_frame(store, frame, result)
+    return result
+
+
+__all__ = ["frame_to_init_kwargs", "seed_frame", "AGENT_SOURCE", "HUMAN_SOURCE"]

--- a/CoScientist/context_init/models.py
+++ b/CoScientist/context_init/models.py
@@ -1,0 +1,180 @@
+"""The Research Frame — the framing entities of the meta-model as a filled form.
+
+One frame = one run. The frame mirrors the microfluidics ТЗ shape (blocks of
+fields, each field carrying a provenance status) but its blocks map onto the
+Research Context Graph seeding (``context_init.commit``): question attributes,
+the constraint context star, budgets, tools, empirical base, confirmation
+criteria and the cost model.
+
+``FRAME_SPEC`` is the single source of truth for the block set, in document
+order. Each block declares HOW it seeds the graph (``kind`` + optional
+``subtype``) and its field names. ``ResearchFrame.blank`` builds an all-open
+frame from it, and ``ResearchFrame.normalized`` re-imposes the canonical
+structure on an LLM-produced frame so the model can drift on values but never on
+structure.
+"""
+from __future__ import annotations
+
+from typing import List, Optional, Tuple
+
+from pydantic import BaseModel, Field
+
+from CoScientist.hitl.field_status import FieldStatus, OPEN_STATUSES
+
+
+# ── the canonical frame ───────────────────────────────────────────────────────
+# (title, kind, subtype, usage, field_names). ``kind`` drives graph seeding:
+#   question              -> attrs merged onto the root ResearchQuestion
+#   constraint            -> one Constraint node (attrs.subtype = subtype)
+#   resources             -> one Resource node per field
+#   tools                 -> one Tool node per field
+#   empirical_base        -> one EmpiricalBase node per field
+#   confirmation_criteria -> one ConfirmationCriteria node
+#   cost_model            -> one CostModel node (applies_to the question)
+FrameSpecEntry = Tuple[str, str, Optional[str], str, Tuple[str, ...]]
+
+FRAME_SPEC: Tuple[FrameSpecEntry, ...] = (
+    ("Вопрос исследования", "question", None,
+     "атрибуты корневого исследовательского вопроса",
+     ("formulation", "domain", "specificity", "gap", "decomposition",
+      "target_setting", "research_form", "trl")),
+    ("Режим и завершение", "question", None,
+     "режим применения ИИ и критерий остановки исследования",
+     ("ai_application_model", "completion_criteria")),
+    ("Профиль исследования", "constraint", "profile",
+     "модальность и постановка — определяет активируемые модули",
+     ("modality", "target_setting", "form_trl")),
+    ("Методологические нормы", "constraint", "methodological_norms",
+     "принятые способы проведения исследований этого типа",
+     ("norms",)),
+    ("Теоретические рамки", "constraint", "theoretical_framework",
+     "формальные модели и теории домена",
+     ("frameworks",)),
+    ("Доменные стандарты", "constraint", "domain_standards",
+     "ГОСТ/ISO/ICH/CLSI и требования журналов",
+     ("standards",)),
+    ("Этика и регуляторика", "constraint", "ethics",
+     "жёсткие ограничения, которые нельзя нарушать",
+     ("constraints",)),
+    ("Экспертное знание", "constraint", "expert_knowledge",
+     "неформализованное знание от человека в контуре",
+     ("notes",)),
+    ("Роли участников", "constraint", "roles",
+     "состав лиц, чья деятельность автоматизируется",
+     ("roles",)),
+    ("Ресурсы и бюджеты", "resources", None,
+     "конечные бюджеты — ограничивают критерии завершения",
+     ("gpu_hours", "tokens", "money", "time", "expert_hours")),
+    ("Инструменты", "tools", None,
+     "известные инструменты и их статус",
+     ("computational", "laboratory", "analytical", "informational")),
+    ("Эмпирическая база", "empirical_base", None,
+     "доступные наблюдения, данные и корпус",
+     ("datasets", "corpora", "trusted_kb")),
+    ("Условия подтверждения", "confirmation_criteria", None,
+     "формальные условия достаточности свидетельств",
+     ("threshold", "confirmations_needed", "reproducibility")),
+    ("Модель стоимости", "cost_model", None,
+     "правило стоимости шага и правило остановки по стоимости",
+     ("cost_rule", "stop_rule")),
+)
+
+# Canonical block titles in document order.
+CANONICAL_FRAME_BLOCKS: Tuple[str, ...] = tuple(e[0] for e in FRAME_SPEC)
+
+_SPEC_BY_TITLE = {e[0]: e for e in FRAME_SPEC}
+
+
+class FrameField(BaseModel):
+    """One field of a block: |Поле|Значение|Статус|."""
+
+    name: str = Field(description="Имя поля, напр. «formulation»")
+    value: str = Field(default="Не задано", description="Значение поля")
+    status: FieldStatus = Field(default="не задано")
+
+    def is_set(self) -> bool:
+        return self.status not in OPEN_STATUSES
+
+
+class FrameBlock(BaseModel):
+    """One block of the frame: a titled group of fields with a graph mapping."""
+
+    title: str = Field(description="Название блока, напр. «Профиль исследования»")
+    kind: str = Field(default="question", description="как блок ложится в граф")
+    subtype: Optional[str] = Field(
+        default=None, description="подтип Constraint, если kind == constraint")
+    usage: str = Field(default="", description="как блок используется дальше")
+    fields: List[FrameField] = Field(default_factory=list)
+
+    def set_fields(self) -> List[FrameField]:
+        return [f for f in self.fields if f.is_set()]
+
+
+class ResearchFrame(BaseModel):
+    """Структурированная рамка исследования (framing-сущности мета-модели).
+
+    Blocks in document order, each a group of fields with a provenance status.
+    The blocks seed the Research Context Graph (see ``context_init.commit``).
+    """
+
+    original_request: str = Field(
+        default="", description="Исходный запрос пользователя дословно")
+    blocks: List[FrameBlock] = Field(default_factory=list)
+
+    def block(self, title: str) -> Optional[FrameBlock]:
+        for b in self.blocks:
+            if b.title.strip().lower() == title.strip().lower():
+                return b
+        return None
+
+    def open_fields(self) -> List[Tuple[str, str]]:
+        """(block_title, field_name) for every field still needing a value."""
+        out: List[Tuple[str, str]] = []
+        for b in self.blocks:
+            for f in b.fields:
+                if not f.is_set():
+                    out.append((b.title, f.name))
+        return out
+
+    @classmethod
+    def blank(cls, original_request: str = "") -> "ResearchFrame":
+        """An all-open frame with every canonical block and field."""
+        blocks = [
+            FrameBlock(
+                title=title, kind=kind, subtype=subtype, usage=usage,
+                fields=[FrameField(name=n) for n in field_names],
+            )
+            for title, kind, subtype, usage, field_names in FRAME_SPEC
+        ]
+        return cls(original_request=original_request, blocks=blocks)
+
+    def normalized(self) -> "ResearchFrame":
+        """Re-impose the canonical structure, keeping values/status the model set.
+
+        The LLM may reorder blocks, rename kinds, or drop fields. This maps its
+        output back onto ``FRAME_SPEC`` by title/field name so the graph mapping
+        can never break, while preserving the values and statuses it produced.
+        """
+        blocks: List[FrameBlock] = []
+        for title, kind, subtype, usage, field_names in FRAME_SPEC:
+            src = self.block(title)
+            src_fields = {f.name.strip().lower(): f for f in (src.fields if src else [])}
+            fields = []
+            for n in field_names:
+                got = src_fields.get(n.strip().lower())
+                if got is not None:
+                    fields.append(FrameField(name=n, value=got.value, status=got.status))
+                else:
+                    fields.append(FrameField(name=n))
+            blocks.append(FrameBlock(
+                title=title, kind=kind, subtype=subtype, usage=usage, fields=fields))
+        return ResearchFrame(original_request=self.original_request, blocks=blocks)
+
+
+__all__ = [
+    "CANONICAL_FRAME_BLOCKS",
+    "FRAME_SPEC",
+    "FrameBlock",
+    "FrameField",
+    "ResearchFrame",
+]

--- a/CoScientist/graph/research/schema.py
+++ b/CoScientist/graph/research/schema.py
@@ -37,9 +37,16 @@ NODE_TYPES: Dict[str, NodeTypeSpec] = {s.name: s for s in [
         attr_docs={
             "formulation": "the question itself",
             "domain": "subject area",
+            "specificity": "how narrow/precise the question is",
             "gap": "the knowledge gap it addresses",
+            "decomposition": "sub-questions it breaks into",
             "target_setting": "целевая постановка (what kind of answer is sought)",
-            "research_form": "fundamental / exploratory / applied (+ TRL)",
+            "research_form": "fundamental / exploratory / applied",
+            "trl": "УГТ — technology readiness level",
+            "completion_criteria": "when the research is done: exhaustive / "
+                                   "pragmatic / resource / economic",
+            "ai_application_model": "autonomy level: lab-assistant / assistant / "
+                                    "copilot / architect",
         },
     ),
     NodeTypeSpec(
@@ -357,7 +364,8 @@ def _transitions(*specs) -> FrozenSet[Tuple[str, str, str]]:
 # seeding — the agent is not choosing types freely, the tool constructs them), so
 # they are absent from the orchestrator's mid-run create-set above.
 INIT_SEED_TYPES = frozenset({"ResearchQuestion", "Tool", "Resource",
-                             "EmpiricalBase", "Constraint"})
+                             "EmpiricalBase", "Constraint",
+                             "ConfirmationCriteria", "CostModel"})
 
 
 # Spec §2 roles mapped onto the agents that actually exist in system.yaml:
@@ -449,6 +457,18 @@ AGENT_PERMISSIONS: Dict[str, AgentPerm] = {
         edges=_edges("uses", "consumes", "supports", "refutes", "refines",
                      "relates_to", "derived_from",
                      ("produces", "VerificationMethod", "Evidence")),
+    ),
+    # The pre-stage context-initialization agent seeds the framing frame at the
+    # start of a run. It writes the whole context star through the PRIVILEGED
+    # init path (store.init_research, enforce_permissions=False), so these rights
+    # matter only if it ever writes through research_commit directly; they are
+    # kept aligned with INIT_SEED_TYPES for clarity and for schema tests.
+    "ContextInitAgent": AgentPerm(
+        create=frozenset({"ResearchQuestion", "Constraint", "Tool", "Resource",
+                          "EmpiricalBase", "ConfirmationCriteria", "CostModel"}),
+        update_attrs=frozenset({"ResearchQuestion"}),
+        transitions=frozenset(),
+        edges=_edges("contextualizes", "defines_scope", "applies_to"),
     ),
     # The human writes through the HITL bridge (web endpoint / approval flow),
     # never through an LLM toolset.

--- a/CoScientist/graph/research/store.py
+++ b/CoScientist/graph/research/store.py
@@ -106,41 +106,60 @@ class ResearchGraphStore:
                       constraints: Optional[List[Dict[str, Any]]] = None,
                       tools: Optional[List[Dict[str, Any]]] = None,
                       resources: Optional[List[Dict[str, Any]]] = None,
-                      empirical_bases: Optional[List[Dict[str, Any]]] = None) -> Dict[str, Any]:
+                      empirical_bases: Optional[List[Dict[str, Any]]] = None,
+                      confirmation_criteria: Optional[List[Dict[str, Any]]] = None,
+                      cost_models: Optional[List[Dict[str, Any]]] = None,
+                      question_source: Optional[str] = None) -> Dict[str, Any]:
         """Start a NEW research: root ResearchQuestion + the context star
         (Constraints —contextualizes→ Q, Q —defines_scope→ EmpiricalBases,
-        standalone Tool/Resource nodes). The previous graph, if any, is
-        archived to a timestamped file — only after the new one validates.
+        CostModels —applies_to→ Q, standalone Tool/Resource/ConfirmationCriteria
+        nodes). The previous graph, if any, is archived to a timestamped file —
+        only after the new one validates.
+
+        Each seed item may carry its own ``source`` (e.g. "human" for a field the
+        operator set, "ContextInitAgent" for one the agent drafted) so the graph
+        records the automation-vs-human split; items without it fall back to the
+        top-level ``source``. ``question_source`` sets the root question's source.
         """
         if not (question or "").strip():
             return CommitResult(ok=False, errors=["question must be a non-empty string"],
                                 hint=_COMMIT_HINT).model_dump()
 
-        nodes: List[Dict[str, Any]] = [{
+        root: Dict[str, Any] = {
             "type": "ResearchQuestion", "ref": "q",
             "attrs": {"formulation": question.strip(), **(attrs or {})},
-        }]
+        }
+        if question_source:
+            root["source"] = question_source
+        nodes: List[Dict[str, Any]] = [root]
         edges: List[Dict[str, Any]] = []
 
         def _star(items, node_type, ref_prefix):
             for i, item in enumerate(dict(it) for it in (items or []) if isinstance(it, dict)):
                 status = item.pop("status", None)
+                node_source = item.pop("source", None)
                 a = item.pop("attrs", None) or item  # accept flat or {"attrs": …}
                 draft = {"type": node_type, "ref": f"{ref_prefix}{i}", "attrs": a}
                 if status:
                     draft["status"] = status
+                if node_source:
+                    draft["source"] = node_source
                 nodes.append(draft)
 
         _star(constraints, "Constraint", "c")
         _star(tools, "Tool", "t")
         _star(resources, "Resource", "r")
         _star(empirical_bases, "EmpiricalBase", "eb")
+        _star(confirmation_criteria, "ConfirmationCriteria", "cc")
+        _star(cost_models, "CostModel", "cm")
         for draft in nodes:
             ref = draft["ref"]
             if draft["type"] == "Constraint":
                 edges.append({"type": "contextualizes", "from": f"#{ref}", "to": "#q"})
             elif draft["type"] == "EmpiricalBase":
                 edges.append({"type": "defines_scope", "from": "#q", "to": f"#{ref}"})
+            elif draft["type"] == "CostModel":
+                edges.append({"type": "applies_to", "from": f"#{ref}", "to": "#q"})
 
         with self._lock:
             old_graph, old_meta = self._g, (self._research_id, self._created_at, self._root_id)
@@ -387,7 +406,8 @@ class ResearchGraphStore:
                     ref = None
                 else:
                     refs[ref] = len(creates)
-            creates.append({"ref": ref, "type": ntype, "status": status, "attrs": attrs})
+            creates.append({"ref": ref, "type": ntype, "status": status,
+                            "attrs": attrs, "source": d.get("source")})
 
         # -- edges: resolve endpoints against existing nodes + this commit ---
         staged_edges: List[Dict[str, Any]] = []
@@ -457,11 +477,14 @@ class ResearchGraphStore:
         for c in creates:
             nid = self._next_id(c["type"])
             attrs = self._truncate_attrs(c["attrs"], warnings)
+            # A per-node source (e.g. "human" for an operator-set frame field)
+            # overrides the commit's default source; edges/status keep the default.
+            node_source = c.get("source") or source
             node = ResearchNode(
                 id=nid, type=c["type"], attrs=attrs, status=c["status"],
-                source=source, created_at=now, updated_at=now,
+                source=node_source, created_at=now, updated_at=now,
                 status_history=[{"from": None, "to": c["status"],
-                                 "source": source, "at": now}],
+                                 "source": node_source, "at": now}],
             )
             self._g.add_node(nid, **node.model_dump())
             if c["ref"]:

--- a/CoScientist/hitl/field_status.py
+++ b/CoScientist/hitl/field_status.py
@@ -1,0 +1,36 @@
+"""Per-field provenance status, shared by structured HITL intakes.
+
+Lifted from the microfluidics ТЗ model (``microfluidics/models.py``) so every
+structured intake — the ТЗ and the research frame (``context_init/models.py``) —
+uses one status vocabulary. A field is "open" when it has no usable value yet.
+That is what a HITL form uses to decide which fields to ask the human to fill.
+
+Statuses are plain string Literals (not an Enum) so the dicts ADK stores in
+session state and injects into downstream prompts render as readable text.
+"""
+from __future__ import annotations
+
+from typing import Literal
+
+# How a field value was obtained — downstream code treats these differently.
+FieldStatus = Literal[
+    "задано заказчиком",
+    "уточнено оператором",
+    "не задано",
+    "свободный комментарий",
+    "рассчитывается агентом",
+]
+
+# Statuses that mean "there is no usable value here yet".
+OPEN_STATUSES = ("не задано", "рассчитывается агентом")
+
+# The operator set this value by hand in a HITL form.
+OPERATOR_STATUS = "уточнено оператором"
+
+
+def is_open(status: str) -> bool:
+    """True when the field still needs a value (drives the HITL form)."""
+    return status in OPEN_STATUSES
+
+
+__all__ = ["FieldStatus", "OPEN_STATUSES", "OPERATOR_STATUS", "is_open"]

--- a/CoScientist/hitl/models.py
+++ b/CoScientist/hitl/models.py
@@ -22,6 +22,11 @@ class HITLRequest(BaseModel):
     message: str = Field(..., description="Message to the human")
     options: List[str] = Field(default_factory=list, description="Options for selection")
     context: Dict[str, Any] = Field(default_factory=dict, description="Additional context")
+    form: Optional[Dict[str, Any]] = Field(
+        default=None,
+        description="Structured form schema (blocks -> fields) for a per-field "
+                    "intake. When present, the web UI renders a form instead of "
+                    "the free-text review; the answer comes back as form_values.")
     invoked_via: str = Field(default="unspecified", description="Source of the request: callback, tool or internal_loop.")
     timeout_seconds: Optional[float] = Field(default=None, description="Timeout for the request")
 
@@ -32,4 +37,8 @@ class HITLResponse(BaseModel):
     selected_option: Optional[str] = Field(default=None, description="Selected option (for SELECT)")
     instructions: Optional[str] = Field(default=None, description="Edited content (for EDIT)")
     free_input: Optional[str] = Field(default=None, description="Free-form input")
+    form_values: Optional[Dict[str, Any]] = Field(
+        default=None,
+        description="Per-field answers from a structured form: "
+                    "{block_title: {field_name: value}}.")
     approved: bool = Field(default=False, description="Whether the action was approved")

--- a/CoScientist/microfluidics/models.py
+++ b/CoScientist/microfluidics/models.py
@@ -19,21 +19,13 @@ JSON-like text instead of Enum reprs.
 """
 from __future__ import annotations
 
-from typing import List, Literal
+from typing import List
 
 from pydantic import BaseModel, Field
 
-# How a ТЗ field value was obtained — downstream agents treat these differently.
-FieldStatus = Literal[
-    "задано заказчиком",
-    "уточнено оператором",
-    "не задано",
-    "свободный комментарий",
-    "рассчитывается агентом",
-]
-
-# Statuses meaning "there is no usable value here".
-OPEN_STATUSES = ("не задано", "рассчитывается агентом")
+# Field-status vocabulary is shared with the research frame intake — one name
+# for one thing. Re-exported here so existing importers keep working.
+from CoScientist.hitl.field_status import FieldStatus, OPEN_STATUSES
 
 # Canonical block set of the reference ТЗ document, in document order.
 CANONICAL_BLOCKS: tuple[str, ...] = (

--- a/CoScientist/web/handler.py
+++ b/CoScientist/web/handler.py
@@ -155,6 +155,7 @@ class WebHITLHandler(AbstractHITLHandler):
             "message": request.message,
             "options": request.options,
             "context": public_context,
+            "form": request.form,
             "invoked_via": request.invoked_via,
         }
 
@@ -222,6 +223,7 @@ class WebHITLHandler(AbstractHITLHandler):
             selected_option=response_data.get("selected_option"),
             instructions=response_data.get("instructions"),
             free_input=response_data.get("free_input"),
+            form_values=response_data.get("form_values"),
         )
 
     def resolve_request(

--- a/CoScientist/web/templates/index.html
+++ b/CoScientist/web/templates/index.html
@@ -474,6 +474,15 @@
       const panel = document.getElementById('hitl-panel');
       const feed = document.getElementById('chat-feed');
 
+      // Structured intake (e.g. the research frame): render a per-field form
+      // instead of the free-text review, then stop — the other HITL points keep
+      // the free-text / option path below.
+      if (data.form && Array.isArray(data.form.blocks)) {
+        renderHitlForm(panel, feed, data);
+        scrollChat();
+        return;
+      }
+
       let openRoadmapSidebarBtn = '';
       let openRoadmapChatBtn = '';
       if (data.agent_name === 'PlannerAgent') {
@@ -655,6 +664,95 @@
         currentPlannerHitlRequest = null;
         updateRoadmapModalButtons();
       }
+    }
+
+    // ── Structured frame form (research frame intake) ────────────────────────
+    function renderHitlForm(panel, feed, data) {
+      const form = data.form;
+      const rid = data.request_id;
+      const blocksHtml = form.blocks.map((b, bi) => {
+        const fieldsHtml = (b.fields || []).map((f, fi) => {
+          const openTag = f.open
+            ? '<span class="text-[9px] text-error uppercase tracking-wider">не задано</span>'
+            : `<span class="text-[9px] text-outline-variant uppercase tracking-wider">${escHtml(f.status || '')}</span>`;
+          const val = f.open ? '' : String(f.value || '');
+          return `
+            <div class="flex flex-col gap-1">
+              <div class="flex items-center justify-between">
+                <label class="text-[11px] font-mono text-on-surface-variant">${escHtml(f.name)}</label>
+                ${openTag}
+              </div>
+              <textarea id="frm-${rid}-${bi}-${fi}" data-block="${escJs(b.title)}" data-field="${escJs(f.name)}"
+                rows="2" placeholder="${escHtml(f.placeholder || 'Оставьте пустым, чтобы агент подставил рабочее значение')}"
+                class="w-full bg-surface-container-high border border-outline-variant/20 rounded-md p-2 font-mono text-[11px] text-on-surface placeholder:text-outline-variant focus:outline-none focus:border-primary/50">${escHtml(val)}</textarea>
+            </div>`;
+        }).join('');
+        return `
+          <div class="mt-3 border border-outline-variant/10 rounded-lg p-3 bg-surface-container-high/40">
+            <p class="text-[11px] font-bold text-on-surface uppercase tracking-wider">${escHtml(b.title)}</p>
+            ${b.usage ? `<p class="text-[10px] text-outline-variant mb-2">${escHtml(b.usage)}</p>` : '<div class="mb-2"></div>'}
+            <div class="flex flex-col gap-2">${fieldsHtml}</div>
+          </div>`;
+      }).join('');
+
+      panel.classList.remove('hidden');
+      panel.innerHTML = `
+        <div class="relative bg-surface-container-lowest p-4 rounded-xl border border-primary/30 shadow-2xl flex flex-col gap-2">
+          <h3 class="font-headline font-bold text-on-surface text-sm uppercase tracking-tight">Рамка исследования</h3>
+          <p class="text-[11px] text-on-surface-variant">Заполните форму в чате. Пустые поля агент заполнит сам.</p>
+        </div>`;
+
+      feed.innerHTML += `
+        <div id="hitl-controls-${rid}" class="my-6 relative msg-enter">
+          <div class="relative bg-surface-container-lowest p-6 rounded-xl border border-primary/30 shadow-2xl">
+            <div class="flex items-center gap-3 mb-2">
+              <div class="w-8 h-8 rounded-full bg-primary flex items-center justify-center shadow-[0_0_15px_rgba(0,218,243,0.4)]">
+                <span class="material-symbols-outlined text-on-primary text-sm">fact_check</span>
+              </div>
+              <h3 class="font-headline font-bold text-on-surface uppercase tracking-tight">${escHtml(form.title || 'Рамка исследования')}</h3>
+            </div>
+            <p class="text-xs text-on-surface-variant leading-relaxed">${escHtml(form.intro || data.message || '')}</p>
+            ${blocksHtml}
+            <div class="flex flex-wrap gap-3 mt-4">
+              <button onclick="respondHITLForm('${rid}', true)" class="flex items-center justify-center gap-2 bg-primary text-on-primary px-4 py-2 rounded-md font-bold text-[10px] uppercase tracking-[0.15em] shadow-lg shadow-primary/20 hover:brightness-110 active:scale-95 transition-all">
+                <span class="material-symbols-outlined text-base">check_circle</span> Сохранить рамку
+              </button>
+              <button onclick="respondHITLForm('${rid}', false)" class="flex items-center justify-center gap-2 bg-surface-container-high border border-outline-variant/20 text-on-surface px-4 py-2 rounded-md font-bold text-[10px] uppercase tracking-[0.15em] hover:bg-surface-container-highest transition-all">
+                <span class="material-symbols-outlined text-base">skip_next</span> Пропустить (агент решит)
+              </button>
+            </div>
+          </div>
+        </div>`;
+    }
+
+    function respondHITLForm(requestId, collect) {
+      // collect=true: gather every non-empty field into form_values so the agent
+      // marks them operator-set; collect=false: submit nothing (soft gate — the
+      // run proceeds with the agent's drafted values).
+      let formValues = null;
+      if (collect) {
+        formValues = {};
+        document.querySelectorAll(`#hitl-controls-${requestId} textarea[data-field]`).forEach(el => {
+          const v = el.value.trim();
+          if (!v) return;
+          const block = el.getAttribute('data-block');
+          const field = el.getAttribute('data-field');
+          (formValues[block] = formValues[block] || {})[field] = v;
+        });
+      }
+      if (ws && ws.readyState === 1) {
+        ws.send(JSON.stringify({
+          type: 'hitl_response',
+          request_id: requestId,
+          action: 'approve',
+          approved: true,
+          form_values: formValues,
+        }));
+      }
+      document.getElementById('hitl-panel').classList.add('hidden');
+      disableHitlControls(requestId);
+      const n = formValues ? Object.values(formValues).reduce((s, o) => s + Object.keys(o).length, 0) : 0;
+      addSystemMsg(collect ? `✓ Рамка сохранена (${n} поле(й) заданы оператором)` : '→ Рамка пропущена — агент подставит значения');
     }
 
     // =========================================================================

--- a/tests/unit/test_assembly.py
+++ b/tests/unit/test_assembly.py
@@ -49,15 +49,19 @@ def test_pipeline_stages_are_declared_agents_and_not_root(config):
 
 
 def test_run_root_is_one_sequential_run_ending_in_the_aggregator():
-    """The whole lifecycle is ONE ADK SequentialAgent (orchestrator → aggregator)
-    driven by a single run_async — so it is one invocation / one Opik trace with the
-    Result Aggregator as the terminal stage (no separate static-directive run)."""
+    """The whole lifecycle is ONE ADK SequentialAgent (context-init pre-stage →
+    orchestrator → aggregator) driven by a single run_async — so it is one
+    invocation / one Opik trace with the Result Aggregator as the terminal stage
+    (no separate static-directive run)."""
     from google.adk.agents.sequential_agent import SequentialAgent
     from CoScientist.agents import run_root, orchestrator_agent
 
     assert isinstance(run_root, SequentialAgent)
     names = [a.name for a in run_root.sub_agents]
-    assert names[0] == orchestrator_agent.name == "OrchestratorAgent"
+    # The context-init pre-stage seeds the research frame before the orchestrator.
+    assert names[0] == "ContextInitAgent", "context-init runs before the orchestrator"
+    assert orchestrator_agent.name == "OrchestratorAgent"
+    assert names.index("OrchestratorAgent") < names.index("ResultAggregatorAgent")
     assert names[-1] == "ResultAggregatorAgent", "aggregator must be the terminal stage"
 
 

--- a/tests/unit/test_context_init.py
+++ b/tests/unit/test_context_init.py
@@ -1,0 +1,165 @@
+"""Context-initialization pre-stage: research frame, gap detection, graph seeding.
+
+The 6-layer meta-model is already the research-graph schema; this stage FILLS the
+framing entities each run. These tests cover the frame model, the structured-form
+round-trip, the privileged graph seeding (with human-vs-agent provenance), and the
+schema permissions for the new ContextInitAgent writer.
+"""
+from collections import Counter
+
+from CoScientist.context_init.agent import (
+    apply_form_values,
+    coerce_frame,
+    frame_to_form,
+)
+from CoScientist.context_init.commit import frame_to_init_kwargs, seed_frame
+from CoScientist.context_init.models import CANONICAL_FRAME_BLOCKS, ResearchFrame
+from CoScientist.graph.research import schema
+from CoScientist.graph.research.store import ResearchGraphStore
+
+
+def _filled_frame() -> ResearchFrame:
+    f = ResearchFrame.blank("Does drug X reduce tumor growth?")
+    q = f.block("Вопрос исследования")
+    for fld in q.fields:
+        if fld.name == "formulation":
+            fld.value, fld.status = "Does drug X reduce tumor growth?", "задано заказчиком"
+        if fld.name == "domain":
+            fld.value, fld.status = "oncology", "уточнено оператором"
+    eth = f.block("Этика и регуляторика")
+    eth.fields[0].value, eth.fields[0].status = "IRB approval", "уточнено оператором"
+    res = f.block("Ресурсы и бюджеты")
+    res.fields[0].value, res.fields[0].status = "100 / 100", "задано заказчиком"
+    cc = f.block("Условия подтверждения")
+    cc.fields[0].value, cc.fields[0].status = "p<0.05", "уточнено оператором"
+    cm = f.block("Модель стоимости")
+    cm.fields[0].value, cm.fields[0].status = "GPU-hours * rate", "уточнено оператором"
+    return f
+
+
+# ── frame model + gap detection ───────────────────────────────────────────────
+
+def test_blank_frame_has_every_canonical_block_all_open():
+    f = ResearchFrame.blank("q")
+    assert [b.title for b in f.blocks] == list(CANONICAL_FRAME_BLOCKS)
+    # every field is open in a blank frame
+    assert all(not fld.is_set() for b in f.blocks for fld in b.fields)
+    assert len(f.open_fields()) == sum(len(b.fields) for b in f.blocks)
+
+
+def test_open_fields_shrink_as_fields_are_filled():
+    f = _filled_frame()
+    open_names = {name for _title, name in f.open_fields()}
+    assert "formulation" not in open_names   # filled
+    assert "trl" in open_names               # still open
+
+
+def test_normalized_reimposes_structure_and_keeps_values():
+    f = ResearchFrame.blank("q")
+    # an LLM that dropped a block and added a junk one
+    f.blocks = [b for b in f.blocks if b.title != "Инструменты"]
+    f.blocks.append(type(f.blocks[0])(title="Мусор", fields=[]))
+    q = f.block("Вопрос исследования")
+    q.fields[0].value, q.fields[0].status = "kept", "задано заказчиком"
+    n = f.normalized()
+    assert [b.title for b in n.blocks] == list(CANONICAL_FRAME_BLOCKS)  # junk gone, block back
+    assert n.block("Вопрос исследования").fields[0].value == "kept"     # value preserved
+
+
+# ── structured form round-trip ────────────────────────────────────────────────
+
+def test_frame_to_form_marks_open_fields():
+    form = frame_to_form(_filled_frame())
+    assert form["blocks"][0]["title"] == "Вопрос исследования"
+    by_name = {fld["name"]: fld for fld in form["blocks"][0]["fields"]}
+    assert by_name["formulation"]["open"] is False
+    assert by_name["trl"]["open"] is True
+
+
+def test_apply_form_values_sets_operator_status_and_is_soft():
+    f = ResearchFrame.blank("q")
+    out = apply_form_values(f, {"Вопрос исследования": {"domain": "physics"}})
+    q = out.block("Вопрос исследования")
+    domain = next(x for x in q.fields if x.name == "domain")
+    assert (domain.value, domain.status) == ("physics", "уточнено оператором")
+    # untouched fields stay open — the soft gate does not force every field
+    assert next(x for x in q.fields if x.name == "trl").is_set() is False
+
+
+def test_apply_form_values_none_is_noop():
+    f = _filled_frame()
+    assert apply_form_values(f, None).model_dump() == f.normalized().model_dump()
+
+
+def test_coerce_frame_accepts_dict_and_json():
+    f = _filled_frame()
+    assert isinstance(coerce_frame(f.model_dump()), ResearchFrame)
+    assert isinstance(coerce_frame(f.model_dump_json()), ResearchFrame)
+
+
+# ── privileged graph seeding ──────────────────────────────────────────────────
+
+def test_seed_frame_writes_expected_nodes(tmp_path):
+    store = ResearchGraphStore(directory=str(tmp_path))
+    result = seed_frame(store, _filled_frame())
+    assert result["ok"] is True
+
+    g = store.full_graph()
+    types = Counter(d.get("type") for _n, d in g.nodes(data=True))
+    assert types["ResearchQuestion"] == 1
+    assert types["Constraint"] == 1
+    assert types["Resource"] == 1
+    assert types["ConfirmationCriteria"] == 1
+    assert types["CostModel"] == 1
+
+
+def test_seed_frame_provenance_and_edges(tmp_path):
+    store = ResearchGraphStore(directory=str(tmp_path))
+    seed_frame(store, _filled_frame())
+    g = store.full_graph()
+
+    # operator/customer-set fields are attributed to the human, not the agent
+    for _n, d in g.nodes(data=True):
+        if d.get("type") in ("Constraint", "Resource", "CostModel"):
+            assert d.get("source") == "human"
+
+    # CostModel applies_to the root question; Constraint contextualizes it
+    edge_types = {k for _u, _v, k in g.edges(keys=True)}
+    assert "applies_to" in edge_types
+    assert "contextualizes" in edge_types
+
+
+def test_init_research_honors_per_node_source(tmp_path):
+    store = ResearchGraphStore(directory=str(tmp_path))
+    out = store.init_research(
+        source="ContextInitAgent",
+        question="q",
+        constraints=[{"subtype": "ethics", "content": "x", "source": "human"}],
+        cost_models=[{"attrs": {"rule": "r"}}],  # no per-node source -> default
+    )
+    assert out["ok"] is True
+    g = store.full_graph()
+    sources = {d["type"]: d["source"] for _n, d in g.nodes(data=True)}
+    assert sources["Constraint"] == "human"          # per-node override
+    assert sources["CostModel"] == "ContextInitAgent"  # falls back to default
+
+
+# ── schema permissions for the new writer ─────────────────────────────────────
+
+def test_context_init_agent_may_write_its_frame():
+    assert schema.validate_node_draft(
+        "ContextInitAgent", "Constraint", "active",
+        {"subtype": "ethics", "content": "x"}) == []
+    assert schema.validate_node_draft(
+        "ContextInitAgent", "CostModel", "created", {}) == []
+    assert schema.validate_edge(
+        "ContextInitAgent", "contextualizes", "Constraint", "ResearchQuestion") == []
+    assert schema.validate_edge(
+        "ContextInitAgent", "applies_to", "CostModel", "ResearchQuestion") == []
+
+
+def test_context_init_agent_cannot_write_others_nodes():
+    assert schema.validate_node_draft(
+        "ContextInitAgent", "Hypothesis", "formulated", {})
+    assert schema.validate_edge(
+        "ContextInitAgent", "supports", "Evidence", "Hypothesis")


### PR DESCRIPTION
Add a pre-stage that drafts the meta-model Research Frame, confirms it through a structured web form, and seeds it into the Research Context Graph before the orchestrator picks a strategy.

New CoScientist/context_init package:
- models.py: ResearchFrame, FRAME_SPEC (14 blocks / 36 fields), gap logic.
- agent.py: ContextInitAgent (pipeline.pre) and its session review loop.
- commit.py: seed_frame maps the frame onto the privileged init_research path and writes a research_frame.json sidecar for durable per-field provenance.

Shared field-status vocabulary lifted to hitl/field_status.py; the microfluidics subsystem re-imports it. Add a structured-form HITL point (HITLRequest.form / HITLResponse.form_values) rendered in the web UI. Extend the graph: ContextInitAgent write permissions, ConfirmationCriteria and CostModel at init, richer ResearchQuestion attrs. Soft gate via CONTEXT_INIT__ENABLED; the orchestrator prompt adds a frame-gate before costly experiments.

Tests: tests/unit/test_context_init.py.