### PR TITLE
Coscientist core updates for alembic

### DIFF
--- a/CoScientist/assembly/schema.py
+++ b/CoScientist/assembly/schema.py
@@ -20,6 +20,11 @@ The YAML declares every agent of the system in one place. Per agent:
   output_key / output_schema / planner / options: passthrough constructor config
                 (an ``options`` value may be "${settings.path}" too)
   a2a:          how the agent is exposed as an A2A service (key, port, skill, env)
+
+A config may also start with ``extends: <name-or-path>``, inheriting another
+config and overriding only the agents and fields it names — so a variant of the
+system (a limited profile, a deployment with one agent off) is a short overlay
+rather than a copy that drifts from the original. See :func:`_merge_raw`.
 """
 from __future__ import annotations
 
@@ -348,11 +353,55 @@ class SystemConfig(BaseModel):
         raise KeyError(f"No agent with a2a key {key!r}. Known: {known}")
 
 
+def _merge_raw(base: Dict[str, Any], overlay: Dict[str, Any]) -> Dict[str, Any]:
+    """Lay an overlay config's raw dict over a base's.
+
+    ``defaults`` merges shallowly. ``agents`` merges per agent — a named
+    agent's fields update the base agent's, so a profile can flip only
+    ``enabled`` without re-declaring the agent, and an agent the base does not
+    have is added whole. Every other top-level section (``pipeline``, and
+    anything added later) is taken from the overlay when it declares one, so a
+    new section can never be silently dropped on the way through an overlay.
+    """
+    merged: Dict[str, Any] = {
+        **base,
+        **{k: v for k, v in overlay.items() if k not in ("defaults", "agents")},
+    }
+    if "defaults" in overlay:
+        merged["defaults"] = {**(base.get("defaults") or {}), **overlay["defaults"]}
+    agents = dict(base.get("agents") or {})
+    for name, cfg in (overlay.get("agents") or {}).items():
+        if isinstance(cfg, dict) and isinstance(agents.get(name), dict):
+            agents[name] = {**agents[name], **cfg}
+        else:
+            agents[name] = cfg
+    merged["agents"] = agents
+    return merged
+
+
+def _load_raw(path: Path, _seen: frozenset = frozenset()) -> Dict[str, Any]:
+    """Load a config's raw dict, resolving an optional ``extends`` overlay.
+
+    A profile sets ``extends: <name-or-path>`` to inherit another config and
+    override only what it names (see :func:`_merge_raw`) instead of copying the
+    whole system — a copy starts drifting from the original the day it is made.
+    ``extends`` chains are followed; a cycle is an error.
+    """
+    path = Path(path).resolve()
+    if path in _seen:
+        raise ValueError(f"Config 'extends' cycle involving {path}")
+    with open(path, encoding="utf-8") as f:
+        raw = yaml.safe_load(f) or {}
+    base_ref = raw.pop("extends", None)
+    if base_ref is None:
+        return raw
+    base = _load_raw(resolve_config_path(str(base_ref)), _seen | {path})
+    return _merge_raw(base, raw)
+
+
 def load_config(path: Optional[Path] = None) -> SystemConfig:
     path = Path(path) if path else resolve_config_path()
-    with open(path, encoding="utf-8") as f:
-        raw = yaml.safe_load(f)
-    return SystemConfig.model_validate(raw)
+    return SystemConfig.model_validate(_load_raw(path))
 
 
 @lru_cache(maxsize=1)

--- a/CoScientist/graph/memory.py
+++ b/CoScientist/graph/memory.py
@@ -143,6 +143,13 @@ class KnowledgeGraph:
         self.ensure_seeded()
         return self._store.full(self.run_id)
 
+    def tool_vs_coder(self) -> Dict[str, Any]:
+        """Whether this run used a tool from the catalogue or wrote code from
+        scratch. See :func:`CoScientist.graph.projection.tool_vs_coder`."""
+        from CoScientist.graph.projection import tool_vs_coder
+
+        return tool_vs_coder(self.full())
+
     def agents_info(self) -> List[Dict[str, Any]]:
         """Structured info about every agent in the system (the roster)."""
         return [

--- a/CoScientist/graph/projection.py
+++ b/CoScientist/graph/projection.py
@@ -56,6 +56,76 @@ def orchestrator_summary(full: dict) -> str:
     return "\n\n".join(blocks)
 
 
+# Toolset bindings that decide which path an agent is on. Derived from the
+# config rather than hardcoded agent names, so renaming or reshaping the agent
+# tree cannot silently break the signal.
+_MCP_TOOLSETS = frozenset({"dynamic_tools"})
+_CODER_TOOLSETS = frozenset({"coder", "sandbox"})
+
+
+def _agents_bound_to(toolsets: frozenset) -> set:
+    from CoScientist.assembly.schema import get_config
+
+    return {
+        name
+        for name, agent in get_config().agents.items()
+        if toolsets & set(agent.tools or ())
+    }
+
+
+def tool_vs_coder(
+    full: dict,
+    *,
+    mcp_agents: Optional[set] = None,
+    coder_agents: Optional[set] = None,
+) -> dict:
+    """Was the work done by a tool from the catalogue, or written from scratch?
+
+    The system is meant to look for an existing tool first and only fall back to
+    writing code. Whether that actually happened is not otherwise recorded
+    anywhere, so a catalogue that has quietly stopped being used looks exactly
+    like one that is working.
+
+    Read off the execution graph the plugin already emits. The two sides are not
+    symmetric, deliberately: for the tool path only a ``tool_call`` counts,
+    because delegating to the executor proves nothing — the catalogue lookup may
+    have come up empty. For the coder, the delegation itself is the evidence
+    that code was written.
+
+    Returns ``{"path", "mcp_tool_calls", "coder_calls"}``, where ``path`` is
+    ``"mcp" | "coder" | "mixed" | "none"``. Works on any run's ``full()`` dict,
+    including a re-loaded snapshot. The agent sets can be passed in for callers
+    that project a graph produced by a different configuration.
+    """
+    mcp_agents = _agents_bound_to(_MCP_TOOLSETS) if mcp_agents is None else mcp_agents
+    coder_agents = (
+        _agents_bound_to(_CODER_TOOLSETS) if coder_agents is None else coder_agents
+    )
+
+    mcp_tool_calls: List[str] = []
+    coder_calls: List[str] = []
+    for n in full.get("nodes", []):
+        kind, who = n.get("kind"), n.get("executor_agent")
+        if kind == "tool_call" and who in mcp_agents:
+            mcp_tool_calls.append(n.get("label") or "")
+        elif kind in ("agent_call", "tool_call") and who in coder_agents:
+            coder_calls.append(n.get("label") or "")
+
+    if mcp_tool_calls and coder_calls:
+        path = "mixed"
+    elif mcp_tool_calls:
+        path = "mcp"
+    elif coder_calls:
+        path = "coder"
+    else:
+        path = "none"
+    return {
+        "path": path,
+        "mcp_tool_calls": mcp_tool_calls,
+        "coder_calls": coder_calls,
+    }
+
+
 def _index(full: dict) -> Dict[str, dict]:
     return {n["id"]: n for n in full.get("nodes", []) if "id" in n}
 

--- a/CoScientist/main.py
+++ b/CoScientist/main.py
@@ -135,10 +135,16 @@ class CoScientistManager:
         session_id: Optional[str] = None,
         hitl_handler: Optional[AbstractHITLHandler] = None,
         session_service: Optional[BaseSessionService] = None,
+        initial_state: Optional[dict] = None,
     ):
         self.app_name = app_name
         self.user_id = user_id or f"user_{uuid4().hex}"
         self.session_id = session_id or f"session_{uuid4().hex}"
+
+        # Extra session state to seed at session creation, for callers that
+        # drive the system programmatically (scripts, reproductions, harnesses)
+        # and need something in state before the first turn.
+        self._initial_state = dict(initial_state or {})
 
         # Web mode injects one shared service so managers can reopen existing
         # sessions. CLI mode falls back to a private in-memory service.
@@ -179,6 +185,9 @@ class CoScientistManager:
                     session_id=self.session_id,
                     state={
                         "active_tasks": [],
+                        **self._initial_state,
+                        # Written last: session scoping is the manager's own and
+                        # a caller must not be able to redirect it.
                         GRAPH_SCOPE_USER_KEY: self.user_id,
                         GRAPH_SCOPE_SESSION_KEY: self.session_id,
                     },

--- a/CoScientist/tools/alembic_tools.py
+++ b/CoScientist/tools/alembic_tools.py
@@ -14,6 +14,7 @@ find and continue an earlier build via ``list_mcp_builds``.
 from __future__ import annotations
 
 import json
+import logging
 import os
 import re
 import secrets
@@ -32,6 +33,8 @@ START_CHAIN = PROJECT_ROOT / "CoScientist" / "alembic" / "start_chain.py"
 # Host-side stdout logs of the build subprocesses (the pipeline's own logs live
 # inside the build container; this is the start_chain wrapper output).
 LOG_DIR = PROJECT_ROOT / ".alembic" / "a2a_builds"
+
+logger = logging.getLogger(__name__)
 
 _LOG_TAIL_LINES = 15
 _MAX_JOBS = 200  # cap registry size; evict oldest finished jobs past this
@@ -233,7 +236,47 @@ async def check_mcp_build(
             return {"status": "error",
                     "error": f"unknown job_id {job_id!r} — use list_mcp_builds() "
                              "to see the builds known to this process."}
-        return _snapshot(rec)
+        out = _snapshot(rec)
+    # Outside the lock: publishing talks to the registry over the network.
+    await _publish_to_catalogue(rec, out, tool_context)
+    return out
+
+
+async def _publish_to_catalogue(
+    rec: Dict[str, Any], out: Dict[str, Any], tool_context: Optional[ToolContext]
+) -> None:
+    """Put a finished build's MCP server where the rest of the system can find it.
+
+    Two destinations, both needed: the rag_tools registry, so Retrieve_tools
+    surfaces the tool in later runs and on other machines; and this session's
+    ``deployed_mcps``, so the executor can call it without waiting for a
+    retrieval round. Without this a build is forgotten the moment it finishes.
+
+    Runs once per job and never raises — a registry that is down must not turn a
+    successful build into a failed tool call. The outcome is reported back to
+    the agent in ``registered``.
+    """
+    if out.get("status") != "done" or not out.get("mcp_url") or rec.get("registered"):
+        return
+    rec["registered"] = True  # one attempt per build, however often it is polled
+
+    from CoScientist.tools.registry_bridge import register_and_resolve
+
+    name = _repo_name(rec["repo_url"])
+    state = {"deployed_mcps": list((getattr(tool_context, "state", None) or {}).get(
+        "deployed_mcps") or [])}
+    try:
+        await register_and_resolve(
+            out["mcp_url"], name, state, description=f"Alembic build of {rec['repo_url']}"
+        )
+    except Exception as exc:  # noqa: BLE001 — the build itself succeeded
+        logger.warning("catalogue registration failed for %s: %s", name, exc)
+        out["registered"] = False
+        out["registration_error"] = f"{type(exc).__name__}: {exc}"
+        return
+    if tool_context is not None:
+        tool_context.state["deployed_mcps"] = state["deployed_mcps"]
+    out["registered"] = True
 
 
 async def list_mcp_builds(tool_context: Optional[ToolContext] = None) -> Dict[str, Any]:

--- a/CoScientist/tools/dynamic_tools.py
+++ b/CoScientist/tools/dynamic_tools.py
@@ -14,6 +14,7 @@ stay equivalent. Best-effort: an unreachable server is skipped, never fatal.
 from __future__ import annotations
 
 import logging
+import os
 from typing import Dict, List, Optional
 
 from google.adk.tools import BaseTool
@@ -23,6 +24,27 @@ from google.adk.tools.mcp_tool import McpToolset
 from google.adk.tools.mcp_tool.mcp_session_manager import StreamableHTTPConnectionParams
 
 logger = logging.getLogger(__name__)
+
+
+def _disable_adk_mcp_mtls_probe() -> None:
+    """Skip ADK's Google-mTLS client-certificate probe on every MCP connect.
+
+    ADK's ``MCPSessionManager`` runs ``google.auth.default()`` +
+    ``configure_mtls_channel()`` before each connection unless
+    ``GOOGLE_API_USE_CLIENT_CERTIFICATE`` is ``false`` (it defaults to ``true``).
+    Plain MCP servers never use Google client certificates, so the probe can
+    only fail — after ~12s, on every single connect, which makes ``get_tools``
+    roughly 75x slower. Worse, it runs while the manager holds its per-loop
+    session lock, so a multi-agent run spends that window serialised behind it.
+
+    ``setdefault`` so a deployment that genuinely uses GCP mTLS can opt back in.
+    The value is read at call time, so setting it here takes effect for every
+    entry point that ends up building an MCP toolset.
+    """
+    os.environ.setdefault("GOOGLE_API_USE_CLIENT_CERTIFICATE", "false")
+
+
+_disable_adk_mcp_mtls_probe()
 
 _SSE_READ_TIMEOUT = 60 * 5.0
 

--- a/CoScientist/tools/embedder_shim.py
+++ b/CoScientist/tools/embedder_shim.py
@@ -1,0 +1,62 @@
+"""Shape-safe wrapper around ``rag_tools``' HTTP embedder.
+
+``BaseEmbedder.embed`` normalises with a hard
+``np.linalg.norm(embeddings, axis=1, keepdims=True)``, which assumes the backend
+always answers with a 2-D batch. ``APIEmbedder._embed_impl`` breaks that
+assumption in two ways:
+
+* it catches **every** transport error and returns ``[]``, so a service outage
+  arrives as ``np.array([])`` — 1-D — and raises ``AxisError: axis 1 is out of
+  bounds for array of dimension 1``, hiding the real cause behind a shape
+  complaint;
+* an embedding service that answers a single-text request with one *flat*
+  vector produces the same 1-D array.
+
+Either way the tool being indexed registers with ``status=error`` and never
+lands in the catalogue, so ``Retrieve_tools`` silently loses it: the system then
+behaves as if the tool did not exist and re-implements the work instead.
+
+:class:`SafeAPIEmbedder` overrides only ``_embed_impl`` — it returns one vector
+per input text, whatever rank the backend answered with, and turns "no usable
+vectors" into an explicit :class:`EmbeddingUnavailableError`. Everything else
+(batching, normalisation, the ``str`` → 1-D / ``list`` → 2-D contract) stays
+with the base class.
+"""
+
+from __future__ import annotations
+
+from typing import Any, List, Optional
+
+import numpy as np
+from rag_tools.retrieval import APIEmbedder
+
+
+class EmbeddingUnavailableError(RuntimeError):
+    """The embedding backend returned no usable vectors for the given texts."""
+
+
+def _as_vectors(raw: Any, expected: int) -> List[np.ndarray]:
+    """``raw`` as exactly ``expected`` 1-D float vectors, whatever its rank."""
+    array = np.asarray(raw, dtype=np.float32)
+    if array.size == 0:
+        raise EmbeddingUnavailableError(
+            f"embedding backend returned no vectors for {expected} text(s) — "
+            "the embedding service is unreachable or erroring"
+        )
+    matrix = np.atleast_2d(array)
+    if matrix.shape[0] != expected:
+        raise EmbeddingUnavailableError(
+            f"embedding backend returned {matrix.shape[0]} vector(s) for "
+            f"{expected} text(s) — refusing to mis-align vectors against their "
+            "payloads"
+        )
+    return list(matrix)
+
+
+class SafeAPIEmbedder(APIEmbedder):
+    """``APIEmbedder`` whose backend answer is always a well-formed batch."""
+
+    async def _embed_impl(
+        self, texts: List[str], batch_size: Optional[int]
+    ) -> List[np.ndarray]:
+        return _as_vectors(await super()._embed_impl(texts, batch_size), len(texts))

--- a/CoScientist/tools/registry_bridge.py
+++ b/CoScientist/tools/registry_bridge.py
@@ -1,0 +1,151 @@
+"""Bridge: a freshly served MCP server → the tool registry + this run's state.
+
+An Alembic build ends with a served FastMCP endpoint (``alembic_tools``'
+``build_mcp_server`` reports its ``mcp_url``), but nothing puts that server
+where CoScientist can find it. The catalogue therefore never grows: the next
+run has no idea the tool exists and re-does the work.
+
+This module closes both halves of that gap:
+
+  (a) :func:`register_mcp_server` ingests the server **and its tools** into the
+      rag_tools registry, so ``Retrieve_tools`` finds it in later runs and on
+      other machines — the durable catalogue;
+  (b) :func:`resolve_into_state` puts the served url into
+      ``state['deployed_mcps']`` — the shape
+      :class:`~CoScientist.tools.dynamic_tools.DynamicMCPToolset` reads — so the
+      executor can call the tool immediately, without waiting for a retrieval
+      round.
+
+``register_mcp_server`` connects to the live server to enumerate its tools, so
+the server must be serving at ``mcp_url`` when it is called.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+
+async def _default_manager():
+    """A rag_tools manager wired from env settings.
+
+    It uses the same embedder/reranker stack as ``Retrieve_tools``
+    (``CoScientist/tools/retrieval_tools.py``) — what we index has to be what
+    retrieval later scores.
+    """
+    import rag_tools
+    from rag_tools.config.settings import get_settings
+    from rag_tools.retrieval import APIReranker, BM25Reranker, HybridReranker
+
+    from CoScientist.tools.embedder_shim import SafeAPIEmbedder
+
+    settings = get_settings()
+    reranker = HybridReranker(
+        [APIReranker(settings.api_reranker), BM25Reranker(settings.bm_reranker)],
+        settings.hybrid_reranker,
+    )
+    return await rag_tools.create_manager(
+        settings, SafeAPIEmbedder(settings.api_embedding), reranker
+    )
+
+
+async def register_mcp_server(
+    mcp_url: str,
+    name: str,
+    description: str = "",
+    *,
+    headers: Optional[Dict[str, str]] = None,
+    manager=None,
+    sync_tools: bool = True,
+):
+    """Ingest a served MCP server and its tools into the rag_tools registry.
+
+    Args:
+        mcp_url: the streamable-http url the server is served at.
+        name: registry name for the server (also part of its ``server_id``).
+        description: optional server description.
+        headers: optional HTTP headers (e.g. auth) for reaching the server.
+        manager: an existing manager to reuse across a batch; when ``None`` one
+            is built from env settings and closed before returning.
+        sync_tools: connect to the live server and index its tools — the point
+            of registering, and the default.
+
+    Returns:
+        The created ``MCPServer``. A failed tool sync leaves it with
+        ``status == ERROR``, logged rather than raised, so a caller registering
+        a batch can record the failure and carry on.
+    """
+    from rag_tools.storage.models import MCPProtocol, ToolStatus
+
+    if not mcp_url:
+        raise ValueError("register_mcp_server: mcp_url is required")
+
+    own_manager = manager is None
+    if own_manager:
+        manager = await _default_manager()
+    try:
+        server = await manager.add_server(
+            name=name,
+            protocol=MCPProtocol.HTTP,
+            url=mcp_url,
+            description=description or "",
+            headers=headers,
+            sync_tools=sync_tools,
+        )
+    finally:
+        if own_manager:
+            await manager.close()
+
+    if getattr(server, "status", None) == ToolStatus.ERROR:
+        logger.warning(
+            "register_mcp_server: %s is registered but its tool sync failed — "
+            "check that it is serving at %s",
+            name,
+            mcp_url,
+        )
+    return server
+
+
+def resolve_into_state(
+    state: Dict[str, Any],
+    server_or_url: Any,
+    name: Optional[str] = None,
+) -> Dict[str, str]:
+    """Add a ``deployed_mcps`` entry so the executor can call the tool this run.
+
+    Accepts either an ``MCPServer`` (its ``url``/``name`` are used) or a bare
+    url. Idempotent by url, so it composes with the retrieval pipeline, which
+    may add the same entry.
+    """
+    url = getattr(server_or_url, "url", None) or server_or_url
+    if not url:
+        raise ValueError("resolve_into_state: no url to resolve")
+
+    entry = {"url": url, "name": name or getattr(server_or_url, "name", None) or url}
+    deployed: List[Dict[str, Any]] = state.setdefault("deployed_mcps", [])
+    if not any(d.get("url") == url for d in deployed):
+        deployed.append(entry)
+    return entry
+
+
+async def register_and_resolve(
+    mcp_url: str,
+    name: str,
+    state: Dict[str, Any],
+    description: str = "",
+    *,
+    headers: Optional[Dict[str, str]] = None,
+    manager=None,
+) -> Tuple[Any, Dict[str, str]]:
+    """Register a served ``mcp_url`` AND wire it into ``state``.
+
+    The one call to make after a build: the tool joins the durable catalogue and
+    becomes callable by the executor in the current run. Returns
+    ``(server, deployed_entry)``.
+    """
+    server = await register_mcp_server(
+        mcp_url, name, description, headers=headers, manager=manager
+    )
+    return server, resolve_into_state(state, server, name)

--- a/CoScientist/tools/retrieval_tools.py
+++ b/CoScientist/tools/retrieval_tools.py
@@ -13,8 +13,10 @@ from CoScientist.storage import RetrievalToolResult
 from rag_tools import create_manager, MCPServer
 from rag_tools.storage import PostgresClient
 from rag_tools.config.settings import get_settings
-from rag_tools.retrieval import APIEmbedder, APIReranker, BM25Reranker, HybridReranker
+from rag_tools.retrieval import APIReranker, BM25Reranker, HybridReranker
 from rag_tools.storage.models import RetrievalResult
+
+from CoScientist.tools.embedder_shim import SafeAPIEmbedder
 
 settings = get_settings()
 _logger = logging.getLogger(__name__)
@@ -103,7 +105,7 @@ class RetrievalToolSet(BaseToolset):
         """
         manager = None
         try:
-            embedder = APIEmbedder(settings.api_embedding)
+            embedder = SafeAPIEmbedder(settings.api_embedding)
             api_reranker = APIReranker(settings.api_reranker)
             bm2_reranker = BM25Reranker(settings.bm_reranker)
             reranker = HybridReranker([api_reranker, bm2_reranker], settings.hybrid_reranker)

--- a/tests/unit/test_config_overlays.py
+++ b/tests/unit/test_config_overlays.py
@@ -1,0 +1,93 @@
+"""``extends:`` — a config variant is an overlay, not a copy.
+
+A copy of system.yaml starts drifting from the original the day it is made, so
+a profile inherits and overrides only what it names. The merge has to be
+faithful in three ways: per-agent fields merge (flipping ``enabled`` must not
+erase the agent's model or prompt), sections the overlay declares win, and a
+cycle is an error rather than a hang.
+"""
+
+import pytest
+
+from CoScientist.assembly.schema import load_config
+
+_BASE = """
+defaults:
+  model: main
+agents:
+  Root:
+    class: llm
+    description: the root
+    root: true
+    model: coder
+    subordinates: [Helper]
+  Helper:
+    class: llm
+    description: a helper
+    prompt: helper_prompt
+"""
+
+
+def _write(tmp_path, name, text):
+    path = tmp_path / name
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def test_an_overlay_flips_one_field_and_keeps_the_rest(tmp_path):
+    base = _write(tmp_path, "base.yaml", _BASE)
+    overlay = _write(
+        tmp_path, "profile.yaml", f"extends: {base}\nagents:\n  Helper:\n    enabled: false\n"
+    )
+
+    config = load_config(overlay)
+
+    assert not config.agent("Helper").is_enabled()
+    assert config.agent("Helper").prompt == "helper_prompt"  # not erased
+    assert config.agent("Root").model == "coder"  # untouched agents survive
+
+
+def test_an_overlay_can_add_an_agent(tmp_path):
+    base = _write(tmp_path, "base.yaml", _BASE)
+    overlay = _write(
+        tmp_path,
+        "profile.yaml",
+        f"extends: {base}\nagents:\n  Extra:\n    class: llm\n    description: extra\n",
+    )
+
+    assert load_config(overlay).agent("Extra").description == "extra"
+
+
+def test_defaults_merge_shallowly(tmp_path):
+    base = _write(tmp_path, "base.yaml", _BASE)
+    overlay = _write(
+        tmp_path, "profile.yaml", f"extends: {base}\ndefaults:\n  model: coder\n"
+    )
+
+    assert load_config(overlay).defaults.model == "coder"
+
+
+def test_an_overlay_keeps_its_own_top_level_section(tmp_path):
+    """defaults and agents merge specially; every other section must still pass
+    through, or an overlay silently inherits the base's lifecycle stages."""
+    base = _write(tmp_path, "base.yaml", _BASE + "pipeline:\n  pre: [Helper]\n")
+    overlay = _write(tmp_path, "profile.yaml", f"extends: {base}\npipeline:\n  pre: []\n")
+
+    assert load_config(base).pipeline.pre == ["Helper"]
+    assert load_config(overlay).pipeline.pre == []
+
+
+def test_a_config_without_extends_is_unaffected(tmp_path):
+    base = _write(tmp_path, "base.yaml", _BASE)
+
+    assert load_config(base).agent("Root").model == "coder"
+
+
+def test_an_extends_cycle_is_an_error(tmp_path):
+    a = tmp_path / "a.yaml"
+    b = tmp_path / "b.yaml"
+    a.write_text(f"extends: {b}\nagents: {{}}\n", encoding="utf-8")
+    b.write_text(f"extends: {a}\nagents: {{}}\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="cycle"):
+        load_config(a)

--- a/tests/unit/test_embedder_shim.py
+++ b/tests/unit/test_embedder_shim.py
@@ -1,0 +1,74 @@
+"""SafeAPIEmbedder: whatever shape the embedding service answers with, a tool
+still gets indexed — or the failure is explicit. No network; the HTTP call is
+replaced.
+
+The bug this guards: rag_tools' APIEmbedder swallows transport errors and
+returns ``[]``, and some services answer a one-text request with a flat vector.
+Both make ``BaseEmbedder.embed`` raise AxisError while normalising, so the tool
+being indexed registers with status=error and silently disappears from the
+catalogue — the system then behaves as if it never existed.
+"""
+
+import asyncio
+
+import numpy as np
+import pytest
+from rag_tools.retrieval import APIEmbedder
+
+from CoScientist.tools.embedder_shim import EmbeddingUnavailableError, SafeAPIEmbedder
+
+
+def _embedder(monkeypatch, answer):
+    """A SafeAPIEmbedder whose backend always answers with ``answer``.
+
+    ``__new__`` skips ``APIEmbedder.__init__`` so the test needs no settings;
+    the patched base ``_embed_impl`` is the HTTP call the wrapper delegates to.
+    """
+
+    async def _backend(self, texts, batch_size):
+        return answer
+
+    monkeypatch.setattr(APIEmbedder, "_embed_impl", _backend)
+    emb = SafeAPIEmbedder.__new__(SafeAPIEmbedder)
+    emb._initialized = True
+    emb._embedding_dim = 3
+    return emb
+
+
+def test_a_flat_single_vector_is_still_a_batch_of_one(monkeypatch):
+    """A service that answers one text with a bare vector must not blow up."""
+    emb = _embedder(monkeypatch, [0.0, 3.0, 4.0])
+
+    out = asyncio.run(emb.embed("one chunk"))
+
+    assert out.shape == (3,)  # single text in, single vector out
+    assert out == pytest.approx([0.0, 0.6, 0.8], abs=1e-6)  # L2-normalised
+
+
+def test_a_normal_batch_is_unchanged(monkeypatch):
+    emb = _embedder(
+        monkeypatch, [np.array([3.0, 0.0, 0.0]), np.array([0.0, 0.0, 5.0])]
+    )
+
+    out = asyncio.run(emb.embed(["a", "b"]))
+
+    assert out.shape == (2, 3)
+    assert out[0] == pytest.approx([1.0, 0.0, 0.0], abs=1e-6)
+    assert out[1] == pytest.approx([0.0, 0.0, 1.0], abs=1e-6)
+
+
+def test_an_unreachable_service_says_so_instead_of_raising_axiserror(monkeypatch):
+    """APIEmbedder returns [] on any transport error. That must not surface as a
+    shape complaint, or the real cause never reaches the caller."""
+    emb = _embedder(monkeypatch, [])
+
+    with pytest.raises(EmbeddingUnavailableError, match="unreachable"):
+        asyncio.run(emb.embed(["a"]))
+
+
+def test_a_short_answer_is_refused_rather_than_mis_aligned(monkeypatch):
+    """Fewer vectors than texts would silently pair chunk 2 with vector 1."""
+    emb = _embedder(monkeypatch, [np.array([1.0, 0.0, 0.0])])
+
+    with pytest.raises(EmbeddingUnavailableError, match="1 vector"):
+        asyncio.run(emb.embed(["a", "b"]))

--- a/tests/unit/test_manager_sessions.py
+++ b/tests/unit/test_manager_sessions.py
@@ -86,3 +86,53 @@ def test_manager_close_awaits_runner_before_resetting_lifecycle_state():
         assert manager._initialized is False
 
     asyncio.run(scenario())
+
+
+def test_initial_state_is_seeded_without_dropping_the_defaults():
+    """Callers that drive the system programmatically need state in place
+    before the first turn; the manager's own session scoping stays authoritative."""
+
+    async def scenario():
+        service = InMemorySessionService()
+        with patch("CoScientist.main.Runner", _Runner):
+            manager = CoScientistManager(
+                user_id="user_a",
+                session_id="session_a",
+                session_service=service,
+                initial_state={"deployed_mcps": [{"url": "http://h:8000/mcp"}]},
+            )
+            await manager.initialize()
+            return await service.get_session(
+                app_name=manager.app_name,
+                user_id="user_a",
+                session_id="session_a",
+            )
+
+    state = asyncio.run(scenario()).state
+    assert state["deployed_mcps"] == [{"url": "http://h:8000/mcp"}]
+    assert state["active_tasks"] == []
+
+
+def test_a_caller_cannot_redirect_the_session_scope():
+    """Scope keys decide whose graph a run writes to — not the caller's to set."""
+
+    async def scenario():
+        service = InMemorySessionService()
+        from CoScientist.graph.session_scope import GRAPH_SCOPE_USER_KEY
+
+        with patch("CoScientist.main.Runner", _Runner):
+            manager = CoScientistManager(
+                user_id="user_a",
+                session_id="session_a",
+                session_service=service,
+                initial_state={GRAPH_SCOPE_USER_KEY: "someone_else"},
+            )
+            await manager.initialize()
+            session = await service.get_session(
+                app_name=manager.app_name,
+                user_id="user_a",
+                session_id="session_a",
+            )
+            return session.state[GRAPH_SCOPE_USER_KEY]
+
+    assert asyncio.run(scenario()) == "user_a"

--- a/tests/unit/test_mcp_mtls_probe_disabled.py
+++ b/tests/unit/test_mcp_mtls_probe_disabled.py
@@ -1,0 +1,35 @@
+"""Importing the MCP toolset must turn ADK's Google-mTLS probe off.
+
+ADK runs google.auth.default() + configure_mtls_channel() before every MCP
+connection unless GOOGLE_API_USE_CLIENT_CERTIFICATE is "false". For plain MCP
+servers that probe can only fail, and it costs ~12s per connect while the
+session lock is held. A deployment that really does use GCP client certificates
+must still be able to say so.
+"""
+
+import os
+
+from CoScientist.tools.dynamic_tools import _disable_adk_mcp_mtls_probe
+
+_VAR = "GOOGLE_API_USE_CLIENT_CERTIFICATE"
+
+
+def test_the_probe_is_off_once_the_toolset_module_is_imported():
+    assert os.environ[_VAR] == "false"
+
+
+def test_the_default_is_applied_when_nothing_is_set(monkeypatch):
+    monkeypatch.delenv(_VAR, raising=False)
+
+    _disable_adk_mcp_mtls_probe()
+
+    assert os.environ[_VAR] == "false"
+
+
+def test_an_explicit_choice_is_left_alone(monkeypatch):
+    """A deployment that really uses GCP client certificates keeps its setting."""
+    monkeypatch.setenv(_VAR, "true")
+
+    _disable_adk_mcp_mtls_probe()
+
+    assert os.environ[_VAR] == "true"

--- a/tests/unit/test_registry_bridge.py
+++ b/tests/unit/test_registry_bridge.py
@@ -1,0 +1,184 @@
+"""A built MCP server has to reach two places: the durable catalogue (so later
+runs find it) and this run's state (so the executor can call it now). No
+network, no database — the rag_tools manager is injected.
+"""
+
+import asyncio
+
+import pytest
+
+from CoScientist.tools.registry_bridge import (
+    register_and_resolve,
+    register_mcp_server,
+    resolve_into_state,
+)
+
+
+class _Server:
+    def __init__(self, url, name):
+        self.url = url
+        self.name = name
+        self.status = "ok"
+
+
+class _Manager:
+    """Records what was registered; stands in for a live rag_tools manager."""
+
+    def __init__(self):
+        self.added = []
+        self.closed = False
+
+    async def add_server(self, *, name, protocol, url, description, headers, sync_tools):
+        self.added.append(
+            {"name": name, "url": url, "sync_tools": sync_tools, "headers": headers}
+        )
+        return _Server(url, name)
+
+    async def close(self):
+        self.closed = True
+
+
+def test_registering_indexes_the_server_and_its_tools():
+    manager = _Manager()
+
+    server = asyncio.run(
+        register_mcp_server("http://host:8000/mcp", "medsam", manager=manager)
+    )
+
+    assert manager.added == [
+        {
+            "name": "medsam",
+            "url": "http://host:8000/mcp",
+            "sync_tools": True,  # indexing the tools is the point of registering
+            "headers": None,
+        }
+    ]
+    assert server.url == "http://host:8000/mcp"
+    assert not manager.closed  # an injected manager is the caller's to close
+
+
+def test_a_missing_url_is_refused():
+    with pytest.raises(ValueError):
+        asyncio.run(register_mcp_server("", "medsam", manager=_Manager()))
+
+
+def test_resolving_makes_the_tool_callable_this_run():
+    state = {}
+
+    resolve_into_state(state, _Server("http://host:8000/mcp", "medsam"))
+
+    assert state["deployed_mcps"] == [
+        {"url": "http://host:8000/mcp", "name": "medsam"}
+    ]
+
+
+def test_resolving_the_same_server_twice_adds_one_entry():
+    """Retrieval may add the same server, so this has to compose with it."""
+    state = {"deployed_mcps": [{"url": "http://host:8000/mcp", "name": "medsam"}]}
+
+    resolve_into_state(state, "http://host:8000/mcp", "medsam")
+
+    assert len(state["deployed_mcps"]) == 1
+
+
+def test_resolving_keeps_servers_that_are_already_there():
+    state = {"deployed_mcps": [{"url": "http://other:9000/mcp", "name": "other"}]}
+
+    resolve_into_state(state, _Server("http://host:8000/mcp", "medsam"))
+
+    assert [d["name"] for d in state["deployed_mcps"]] == ["other", "medsam"]
+
+
+def test_one_call_does_both_halves():
+    manager, state = _Manager(), {}
+
+    server, entry = asyncio.run(
+        register_and_resolve(
+            "http://host:8000/mcp", "medsam", state, manager=manager
+        )
+    )
+
+    assert manager.added[0]["url"] == "http://host:8000/mcp"  # in the catalogue
+    assert state["deployed_mcps"] == [entry]  # and callable right now
+    assert server.name == "medsam"
+
+
+# ── the call site: a finished build must reach the catalogue ─────────────────
+
+
+class _Ctx:
+    def __init__(self):
+        self.state = {}
+
+
+def _finished_job(monkeypatch, tmp_path, calls):
+    """A done build in alembic_tools' job registry, with the bridge stubbed."""
+    tmp_log = tmp_path / "build.log"
+    tmp_log.write_text("MCP server: http://host:8000/mcp\n", encoding="utf-8")
+    from CoScientist.tools import alembic_tools
+
+    async def _register_and_resolve(mcp_url, name, state, description="", **kw):
+        calls.append({"url": mcp_url, "name": name})
+        state.setdefault("deployed_mcps", []).append({"url": mcp_url, "name": name})
+        return object(), state["deployed_mcps"][-1]
+
+    monkeypatch.setattr(
+        "CoScientist.tools.registry_bridge.register_and_resolve", _register_and_resolve
+    )
+    rec = {
+        "job_id": "medsam-abc123",
+        "repo_url": "https://github.com/org/medsam.git",
+        "status": "done",
+        "started_at": 0.0,
+        "finished_at": 1.0,
+        "mcp_url": "http://host:8000/mcp",
+        "image": "alembic-tool:medsam",
+        "log_file": str(tmp_log),
+    }
+    monkeypatch.setattr(alembic_tools, "_JOBS", {"medsam-abc123": rec})
+    return alembic_tools, rec
+
+
+def test_a_finished_build_is_registered_and_made_callable(monkeypatch, tmp_path):
+    calls = []
+    alembic_tools, _ = _finished_job(monkeypatch, tmp_path, calls)
+    ctx = _Ctx()
+
+    out = asyncio.run(alembic_tools.check_mcp_build("medsam-abc123", ctx))
+
+    assert calls == [{"url": "http://host:8000/mcp", "name": "medsam"}]
+    assert ctx.state["deployed_mcps"] == [
+        {"url": "http://host:8000/mcp", "name": "medsam"}
+    ]
+    assert out["registered"] is True
+
+
+def test_polling_the_same_build_registers_it_once(monkeypatch, tmp_path):
+    calls = []
+    alembic_tools, _ = _finished_job(monkeypatch, tmp_path, calls)
+    ctx = _Ctx()
+
+    asyncio.run(alembic_tools.check_mcp_build("medsam-abc123", ctx))
+    asyncio.run(alembic_tools.check_mcp_build("medsam-abc123", ctx))
+
+    assert len(calls) == 1
+
+
+def test_a_registry_outage_does_not_fail_the_build(monkeypatch, tmp_path):
+    """The build succeeded. A catalogue that is down is reported, not raised."""
+    calls = []
+    alembic_tools, _ = _finished_job(monkeypatch, tmp_path, calls)
+
+    async def _boom(*a, **kw):
+        raise ConnectionError("registry unreachable")
+
+    monkeypatch.setattr(
+        "CoScientist.tools.registry_bridge.register_and_resolve", _boom
+    )
+
+    out = asyncio.run(alembic_tools.check_mcp_build("medsam-abc123", _Ctx()))
+
+    assert out["status"] == "done"
+    assert out["mcp_url"] == "http://host:8000/mcp"
+    assert out["registered"] is False
+    assert "registry unreachable" in out["registration_error"]

--- a/tests/unit/test_tool_vs_coder.py
+++ b/tests/unit/test_tool_vs_coder.py
@@ -1,0 +1,105 @@
+"""Did a run use a tool from the catalogue, or write the code from scratch?
+
+The system is meant to look for an existing tool first. Nothing else records
+whether it did, so a catalogue that has quietly stopped being used is
+indistinguishable from one that works. The signal is read off the execution
+graph; the agent sets come from the config, so renaming an agent cannot
+silently break it.
+"""
+
+from CoScientist.assembly.schema import get_config
+from CoScientist.graph.projection import _agents_bound_to, tool_vs_coder
+
+_MCP = {"ExperimentAgent"}
+_CODER = {"CoderAgent"}
+
+
+def _graph(*nodes):
+    return {"nodes": list(nodes)}
+
+
+def _node(kind, who, label="x"):
+    return {"id": label, "kind": kind, "executor_agent": who, "label": label}
+
+
+def test_a_catalogue_tool_call_is_the_tool_path():
+    graph = _graph(_node("tool_call", "ExperimentAgent", "segment_image"))
+
+    out = tool_vs_coder(graph, mcp_agents=_MCP, coder_agents=_CODER)
+
+    assert out["path"] == "mcp"
+    assert out["mcp_tool_calls"] == ["segment_image"]
+
+
+def test_delegating_to_the_executor_is_not_enough_on_its_own():
+    """The lookup may have come up empty — only an actual call counts."""
+    graph = _graph(_node("agent_call", "ExperimentAgent", "ExperimentAgent"))
+
+    assert tool_vs_coder(graph, mcp_agents=_MCP, coder_agents=_CODER)["path"] == "none"
+
+
+def test_delegating_to_the_coder_is_enough():
+    """For the coder the delegation itself means code was written."""
+    graph = _graph(_node("agent_call", "CoderAgent", "CoderAgent"))
+
+    out = tool_vs_coder(graph, mcp_agents=_MCP, coder_agents=_CODER)
+
+    assert out["path"] == "coder"
+    assert out["coder_calls"] == ["CoderAgent"]
+
+
+def test_both_paths_in_one_run_read_as_mixed():
+    graph = _graph(
+        _node("tool_call", "ExperimentAgent", "segment_image"),
+        _node("tool_call", "CoderAgent", "execute_bash"),
+    )
+
+    assert tool_vs_coder(graph, mcp_agents=_MCP, coder_agents=_CODER)["path"] == "mixed"
+
+
+def test_unrelated_activity_is_ignored():
+    graph = _graph(
+        _node("tool_call", "ResearchAgent", "tavily_search"),
+        _node("goal", None, "do the thing"),
+    )
+
+    assert tool_vs_coder(graph, mcp_agents=_MCP, coder_agents=_CODER)["path"] == "none"
+
+
+def test_an_empty_graph_is_not_an_error():
+    assert tool_vs_coder({}, mcp_agents=_MCP, coder_agents=_CODER)["path"] == "none"
+
+
+# ── the sets come from the config, not from names written in the code ────────
+
+
+def test_the_tool_path_is_whoever_holds_the_registered_mcp_toolset():
+    agents = _agents_bound_to(frozenset({"dynamic_tools"}))
+
+    assert agents
+    for name in agents:
+        assert "dynamic_tools" in get_config().agent(name).tools
+
+
+def test_the_coder_path_is_whoever_can_run_code():
+    agents = _agents_bound_to(frozenset({"coder", "sandbox"}))
+
+    assert agents
+    for name in agents:
+        assert {"coder", "sandbox"} & set(get_config().agent(name).tools)
+
+
+def test_the_default_sets_are_read_from_the_live_config():
+    """No arguments: the projection still knows both paths."""
+    graph = _graph(_node("tool_call", "ExperimentAgent", "segment_image"))
+
+    assert tool_vs_coder(graph)["path"] == "mcp"
+
+
+def test_the_knowledge_graph_exposes_the_signal(tmp_path):
+    """Callers hold a KnowledgeGraph, not a raw dict."""
+    from CoScientist.graph.memory import KnowledgeGraph
+
+    graph = KnowledgeGraph(run_id="run-x", snapshot_dir=str(tmp_path))
+
+    assert graph.tool_vs_coder()["path"] == "none"


### PR DESCRIPTION
**1. Инструменты больше не пропадают из каталога** · b4d3d6c

  Если сервис эмбеддингов моргнул или ответил чуть в другом формате, инструмент помечался как сломанный и навсегда исчезал из поиска. Система потом
  писала код заново — для того, что у неё уже было. Теперь ответ сервиса приводится к нормальному виду, а если векторов нет вообще — это честная ошибка,
  а не тихая пропажа.

  **2. Минус 12 секунд с каждого подключения к инструменту** · b15bbbe

  Библиотека Google перед каждым подключением проверяла корпоративные сертификаты, которых у наших серверов нет и не будет. Проверка всегда
  проваливалась — через двенадцать секунд, каждый раз, и всё это время держала блокировку. Отключается одной строкой; кому эти сертификаты реально нужны
  — оставляет как было.

  **3. Собранный инструмент попадает в каталог** · 5851e74

  Раньше сборка заканчивалась работающим сервером, о котором никто не знал: следующий запуск делал всё заново. Теперь инструмент сразу и записывается в
  каталог, и становится вызываемым в текущем запуске. Если каталог лежит — сборка всё равно успешна, просто агенту об этом говорят.

  **4. Профиль вместо копии конфига** · e016039

  Чтобы запустить систему в другом составе, приходилось копировать весь файл агентов — и копия тут же начинала жить своей жизнью. Теперь пишешь extends:
  и меняешь только нужное.

  **5. Можно задать состояние сессии на старте** · 00807d1

  Мелочь для тех, кто запускает систему из кода. Свои ключи добавить можно, служебные — нет.

  **6. Видно, чем решена задача** · 56adef3

  Готовым инструментом или кодом с нуля. Без этого нельзя заметить, что каталог перестал работать: неработающий выглядит точно так же, как работающий.