### PR TITLE
Feat: pick the report language per session from the web UI

### DIFF
--- a/CoScientist/agents/callbacks/__init__.py
+++ b/CoScientist/agents/callbacks/__init__.py
@@ -1,4 +1,4 @@
-"""Agent callbacks: tool/reranker, critic, medical, and research callbacks.
+"""Agent callbacks: tool/reranker, critic, medical, research, and report-language callbacks.
 
 Re-exported here so callers can use `from CoScientist.agents.callbacks import
 <name>` regardless of which submodule defines it.
@@ -13,6 +13,7 @@ from CoScientist.agents.callbacks.med_callbacks import (
     med_agent_before_model,
 )
 from CoScientist.agents.callbacks.json_output import sanitize_json_output
+from CoScientist.agents.callbacks.report_language import inject_report_language
 from CoScientist.agents.callbacks.research_callbacks import (
     cleanup_uploaded_papers,
     ensure_local_papers_uploaded,
@@ -54,5 +55,6 @@ __all__ = [
     "before_get_task",
     "inject_graph_root",
     "inject_dataset_context",
+    "inject_report_language",
     "sanitize_json_output",
 ]

--- a/CoScientist/agents/callbacks/report_language.py
+++ b/CoScientist/agents/callbacks/report_language.py
@@ -1,0 +1,130 @@
+"""Report language: the user picks it per session in the web UI.
+
+The Result Aggregator writes the run's final report, and its language is a
+per-session choice — not a build-time constant. An agent instruction is a plain
+string built once per session, so the language cannot come from settings or from
+a ``<<...>>`` template sentinel. It travels as ADK session state instead:
+
+  1. the web layer writes ``state['report_language']`` ("ru" or "en");
+  2. ``inject_report_language`` (before_agent) renders the matching block into
+     ``state['report_language_block']``;
+  3. the prompt carries ``{report_language_block?}`` and ADK substitutes it at
+     run time.
+
+The callback injects the WHOLE language contract, not just a language name. The
+report's section headings, the heading-substitution rule that constrains the
+verbatim ``format_results`` output, and the entity glossary all differ by
+language, so they live here — one block per language, kept parallel line for
+line — and the prompt stays one readable English document.
+"""
+from google.adk.agents.callback_context import CallbackContext
+
+import logging
+logger = logging.getLogger(__name__)
+
+# Set by the web layer (see web/app.py `apply_report_language`).
+REPORT_LANGUAGE_STATE_KEY = "report_language"
+# Rendered by this callback, read by the prompt's {report_language_block?}.
+REPORT_LANGUAGE_BLOCK_STATE_KEY = "report_language_block"
+
+REPORT_LANGUAGES = ("ru", "en")
+# Every entrypoint that does not set the key — the CLI, A2A, alembic — lands
+# here, which reproduces the behavior those paths had before the key existed.
+DEFAULT_REPORT_LANGUAGE = "ru"
+
+
+def normalize_report_language(raw) -> str:
+    """Map any input to a supported language code.
+
+    The single fallback site: a missing key, None, an empty string, and an
+    unsupported code all collapse to DEFAULT_REPORT_LANGUAGE.
+    """
+    lang = str(raw or "").strip().lower()
+    return lang if lang in REPORT_LANGUAGES else DEFAULT_REPORT_LANGUAGE
+
+
+_RU_BLOCK = """### Report language
+
+Write the entire report in Russian. These instructions are in English, the
+report is not. Everything the reader sees is Russian: headings, prose, captions,
+list items, and conclusions.
+
+Heading substitutions inside the `format_results` blocks — these two, and no
+others: `## Figures` becomes `## Иллюстрации`, and `## Data tables` becomes
+`## Таблицы данных`.
+
+Section headings, in this order. The role each one carries is in parentheses,
+so match them to the five sections of step 3:
+`## Цель` (objective), `## Подход` (approach), `## Результаты` (results),
+`## Обсуждение` (discussion), `## Ограничения и дальнейшие шаги`
+(limitations and next steps).
+
+The graph, its node labels, and the digest above are written in English.
+Translate their substance into Russian — never quote an English sentence into
+the report. Keep these untranslated:
+   - numbers, units, formulas, and dates;
+   - node ids, file paths, and links;
+   - citation strings, author names, and paper titles;
+   - code, tool, agent, and parameter identifiers.
+For a domain term whose Russian form is ambiguous, write the Russian term and
+give the English one in parentheses at its first use.
+
+Name the graph entities with the spec's Russian terms: ResearchQuestion —
+исследовательский вопрос, Hypothesis — гипотеза, Evidence — свидетельство,
+Conclusion — заключение, VerificationMethod — метод проверки, Constraint —
+ограничение, Tool — инструмент. Report hypothesis statuses as
+подтверждена / опровергнута / отложена.
+"""
+
+_EN_BLOCK = """### Report language
+
+Write the entire report in English. These instructions are in English, and so is
+the report. Everything the reader sees is English: headings, prose, captions,
+list items, and conclusions.
+
+Heading substitutions inside the `format_results` blocks — none. Keep
+`## Figures` and `## Data tables` exactly as `format_results` returned them.
+
+Section headings, in this order. The role each one carries is in parentheses,
+so match them to the five sections of step 3:
+`## Objective` (objective), `## Approach` (approach), `## Results` (results),
+`## Discussion` (discussion), `## Limitations and next steps`
+(limitations and next steps).
+
+The graph, its node labels, and the digest above are written in English. Use
+their wording directly — no translation step stands between the graph and the
+report. Keep these as they are:
+   - numbers, units, formulas, and dates;
+   - node ids, file paths, and links;
+   - citation strings, author names, and paper titles;
+   - code, tool, agent, and parameter identifiers.
+For a domain term with more than one accepted form, use the form the graph uses
+and stay with it for the whole report.
+
+Name the graph entities with the schema's canonical English terms:
+ResearchQuestion, Hypothesis, Evidence, Conclusion, VerificationMethod,
+Constraint, Tool. Report hypothesis statuses as
+confirmed / refuted / postponed.
+"""
+
+_BLOCKS = {"ru": _RU_BLOCK, "en": _EN_BLOCK}
+
+
+def inject_report_language(callback_context: CallbackContext):
+    """before_agent: render state['report_language'] into the prompt's language block.
+
+    The instruction carries ``{report_language_block?}`` rather than a bare
+    language name, because the headings, the substitution rule, and the glossary
+    all change with the language. Best-effort — a failure here falls back to the
+    default language instead of breaking the run. Returns None so the agent's
+    other before_agent callbacks still run.
+    """
+    try:
+        lang = normalize_report_language(
+            callback_context.state.get(REPORT_LANGUAGE_STATE_KEY)
+        )
+    except Exception:  # noqa: BLE001
+        logger.info("inject_report_language: unreadable state, using the default")
+        lang = DEFAULT_REPORT_LANGUAGE
+    callback_context.state[REPORT_LANGUAGE_BLOCK_STATE_KEY] = _BLOCKS[lang]
+    return None

--- a/CoScientist/agents/prompts/templates.py
+++ b/CoScientist/agents/prompts/templates.py
@@ -2101,10 +2101,10 @@ typed graph of ResearchQuestion → Hypotheses (each confirmed / refuted / postp
 node. Your job is to read that graph and synthesize ONE cohesive, visually rich,
 self-contained Markdown report — the final deliverable a researcher will read.
 
-**WRITE THE REPORT IN RUSSIAN.** Everything the reader sees — headings, prose,
-captions, list items, conclusions — is Russian. These instructions are in English,
-the report is not. The "Language" section below names the parts that stay
-untranslated.
+These instructions are in English. The report is written in the language the
+**Report language** section at the end mandates — in full: headings, prose,
+captions, list items, and conclusions. That section also fixes the section
+headings and the entity names, so read it before you write a line.
 
 The graph is your source of truth, NOT a chat transcript (you have none). The
 system solves open-ended, de-novo scientific questions — do NOT assume this was a
@@ -2124,43 +2124,29 @@ A starting digest of the graph:
    data table the run produced into the report folder and returns ready-to-embed
    Markdown blocks (image embeds with relative paths like `figures/<name>.png`, and
    tables). Embed those blocks VERBATIM — do not rewrite the paths or re-type tables.
-   Exactly two substitutions are allowed, and no others: the block heading
-   `## Figures` becomes `## Иллюстрации`, and `## Data tables` becomes
-   `## Таблицы данных`. The `### <label>` lines under them are FILENAMES — never
-   translate or rename them. Put your Russian caption in a sentence of your own
-   next to the figure instead.
-3. **Write the report.** Structure it clearly with these Russian headings:
-   - **Цель** — the ResearchQuestion in your own words.
-   - **Подход** — the hypotheses explored and the methods/tools/agents used.
-   - **Результаты** — the findings, keyed to the graph's Conclusions and Evidence,
+   Only the heading substitutions listed in the **Report language** section are
+   allowed, and no others. The `### <label>` lines are FILENAMES — never translate
+   or rename them. Put your caption in a sentence of your own next to the figure
+   instead.
+3. **Write the report.** Give it these five sections, in this order. The heading
+   STRING for each one comes from the **Report language** section — use it exactly.
+   - *Objective* — the ResearchQuestion in your own words.
+   - *Approach* — the hypotheses explored and the methods/tools/agents used.
+   - *Results* — the findings, keyed to the graph's Conclusions and Evidence,
      with figures/tables from step 2 placed where they support the text. State
      concrete numbers from the actual Evidence nodes. Report refuted or postponed
      hypotheses honestly as negative results — do not hide them.
-   - **Обсуждение** — interpretation, caveats, discrepancies, and any failures.
-   - **Ограничения и дальнейшие шаги** — what a researcher should do to extend or
-     verify.
+   - *Discussion* — interpretation, caveats, discrepancies, and any failures.
+   - *Limitations & next steps* — what a researcher should do to extend or verify.
 4. **Ground every claim in a graph node.** Do not invent numbers, citations, or
    figures. If the graph is empty or a branch failed, say so plainly rather than
    papering over it.
 5. **No placeholders.** The report must render on its own — every referenced figure
    and table must be one `format_results` actually collected.
 
-### Language
-The graph, its node labels and the digest above are written in English. Translate
-their substance into Russian — never quote an English sentence into the report.
-Keep these untranslated:
-   - numbers, units, formulas, and dates;
-   - node ids, file paths, and links;
-   - citation strings, author names, and paper titles;
-   - code, tool, agent, and parameter identifiers.
-For a domain term whose Russian form is ambiguous, write the Russian term and give
-the English one in parentheses at its first use. Name the graph entities with the
-spec's Russian terms: ResearchQuestion — исследовательский вопрос, Hypothesis —
-гипотеза, Evidence — свидетельство, Conclusion — заключение, VerificationMethod —
-метод проверки, Constraint — ограничение, Tool — инструмент. Report hypothesis
-statuses as подтверждена / опровергнута / отложена.
+{report_language_block?}
 
-Output the complete Markdown report, written in Russian, as your final message.
+Output the complete Markdown report, in the mandated language, as your final message.
 ''')
 
 

--- a/CoScientist/agents/system.yaml
+++ b/CoScientist/agents/system.yaml
@@ -186,7 +186,7 @@ agents:
     # figures/tables collected by format_results, not from the raw transcript.
     include_contents: none
     callbacks:
-      before_agent: [inject_research_context]
+      before_agent: [inject_research_context, inject_report_language]
     output_key: final_report
 
   HypothesesAgent:

--- a/CoScientist/assembly/bindings.py
+++ b/CoScientist/assembly/bindings.py
@@ -807,6 +807,11 @@ def _inject_dataset_context():
     return inject_dataset_context
 
 
+def _inject_report_language():
+    from CoScientist.agents.callbacks import inject_report_language
+    return inject_report_language
+
+
 def _inject_research_context(ctx):
     """before_agent callback seeding state['research_context']. The orchestrator
     (root) gets the overview + trigger digest; a worker gets its focus slice.
@@ -922,6 +927,9 @@ _cb("inject_research_context", "before_agent", factory=_inject_research_context)
 # Tell the agent about the dataset archive the user attached in the web UI; it
 # decides itself which calls need the link.
 _cb("inject_dataset_context", "before_agent", factory=lambda ctx: _inject_dataset_context())
+# Report language the user picked for this session: inject the whole block
+# (headings, substitution rule, glossary), not a bare language name.
+_cb("inject_report_language", "before_agent", factory=lambda ctx: _inject_report_language())
 # Human-In-The-Loop approval callback before model/agent execution.
 _cb("hitl_before_model", "before_model", factory=lambda ctx: _hitl_before_model())
 _cb("hitl_before_agent", "before_agent", factory=lambda ctx: _hitl_before_model())

--- a/CoScientist/web/app.py
+++ b/CoScientist/web/app.py
@@ -17,6 +17,10 @@ from fastapi.responses import HTMLResponse, JSONResponse, Response, StreamingRes
 from fastapi.staticfiles import StaticFiles
 
 from CoScientist.agents.callbacks.tool_callbacks import DATASET_URL_STATE_KEY
+from CoScientist.agents.callbacks.report_language import (
+    REPORT_LANGUAGES,
+    REPORT_LANGUAGE_STATE_KEY,
+)
 from CoScientist.main import CoScientistManager
 from CoScientist.web.handler import WebHITLHandler
 from CoScientist.web.session_registry import LocalSessionRegistry
@@ -96,6 +100,23 @@ def _validated_dataset_url(raw: Any) -> str:
     if not parsed.path.lower().endswith(".zip"):
         raise ValueError("Dataset link must point to a .zip archive.")
     return url
+
+
+def _validated_report_language(raw: Any) -> str:
+    """Normalize the report language the user picked; "" clears the choice.
+
+    A closed enum, so a typo becomes an immediate message instead of a finished
+    report in the wrong language. Clearing it hands the session back to the
+    default that ``normalize_report_language`` applies.
+    """
+    lang = str(raw or "").strip().lower()
+    if not lang:
+        return ""
+    if lang not in REPORT_LANGUAGES:
+        raise ValueError(
+            "Report language must be one of: " + ", ".join(REPORT_LANGUAGES) + "."
+        )
+    return lang
 
 
 def _apply_frontend_settings(frontend: dict) -> None:
@@ -258,6 +279,10 @@ class WebRuntime:
         # here as well as in ADK state so a reconnecting tab and a session whose
         # manager has not been built yet both see the same link.
         self.dataset_urls: dict[SessionKey, str] = {}
+        # Report language chosen for a session from the chat composer. Holds
+        # ONLY explicit choices — an absent key means the browser has not spoken
+        # yet, which is what lets the UI default follow its interface language.
+        self.report_languages: dict[SessionKey, str] = {}
         self.pending_hitl: dict[str, dict[str, Any]] = {}
         self.hitl_handler = WebHITLHandler()
         self.hitl_handler.set_sender(self.send_socket)
@@ -485,6 +510,7 @@ class WebRuntime:
                     "run_status_version": version,
                     "metrics": self.metrics.get(key),
                     "dataset_url": self.dataset_urls.get(key, ""),
+                    "report_language": self.report_languages.get(key, ""),
                 })
             except Exception:
                 self.detach_socket(key, ws)
@@ -525,6 +551,57 @@ class WebRuntime:
                 author="user",
                 actions=EventActions(
                     state_delta={DATASET_URL_STATE_KEY: current},
+                ),
+            ),
+        )
+        return current
+
+    async def apply_report_language(
+        self,
+        key: SessionKey,
+        lang: str | None = None,
+    ) -> str:
+        """Set/clear the session's report language and mirror it into ADK state.
+
+        ``lang=None`` re-syncs the stored choice without changing it — called at
+        the start of every run, because the ADK session may not have existed yet
+        when the user picked the language.
+
+        The mirror holds only explicit choices, and an unset session mirrors ""
+        into state rather than a language. That keeps the one fallback site in
+        ``normalize_report_language``. Writing a default here would turn "the UI
+        default follows its interface language" into "the default is always
+        Russian".
+        """
+        if lang is not None:
+            if lang:
+                self.report_languages[key] = lang
+            else:
+                self.report_languages.pop(key, None)
+        current = self.report_languages.get(key, "")
+        if lang is None and not current:
+            # A re-sync must never downgrade a language already in state to "".
+            # Only an explicit clear does that, so a session whose state carries
+            # a choice the mirror has lost keeps it.
+            return current
+
+        user_id, session_id = key
+        adk_session = await self.session_service.get_session(
+            app_name=APP_NAME,
+            user_id=user_id,
+            session_id=session_id,
+        )
+        if adk_session is None:
+            return current
+        if adk_session.state.get(REPORT_LANGUAGE_STATE_KEY, "") == current:
+            return current
+        await self.session_service.append_event(
+            adk_session,
+            Event(
+                invocation_id=f"reportlang_{uuid4().hex}",
+                author="user",
+                actions=EventActions(
+                    state_delta={REPORT_LANGUAGE_STATE_KEY: current},
                 ),
             ),
         )
@@ -1557,6 +1634,22 @@ def create_app() -> FastAPI:
                         "type": "dataset_url",
                         "dataset_url": url,
                     })
+                elif msg_type == "set_report_language":
+                    try:
+                        lang = _validated_report_language(data.get("report_language"))
+                    except ValueError as exc:
+                        await runtime.send_socket(ws, {
+                            "type": "report_language_rejected",
+                            "message": str(exc),
+                        }, key)
+                        continue
+                    await runtime.apply_report_language(key, lang)
+                    # Broadcast: the report is one document, so every tab on the
+                    # session agrees on its language, whichever one picked it.
+                    await runtime.send(key, {
+                        "type": "report_language",
+                        "report_language": lang,
+                    })
                 elif msg_type == "hitl_response":
                     _handle_hitl_response(runtime, key, data)
                 elif msg_type == "ping":
@@ -1628,6 +1721,9 @@ async def _handle_chat(runtime: WebRuntime, key: SessionKey, data: dict):
         # manager), so mirror it into state now that the session exists — this is
         # what puts the link in front of CoderAgent.
         await runtime.apply_dataset_url(key)
+        # Same reason as the attachment above: the language may have been picked
+        # before the ADK session existed.
+        await runtime.apply_report_language(key)
         runtime.registry.touch_session(user_id, session_id, status="processing")
         execution_lock = runtime.execution_locks[key]
 
@@ -1699,6 +1795,8 @@ async def _run_chat_invocation(
     # The Result Aggregator runs as the terminal stage of the SAME run_async, so its
     # format_results reads report_config mid-invocation — set it before the run.
     # TODO(planning): thread a real ReportConfig (e.g. --latex mode) from the web layer.
+    # The report LANGUAGE is not part of this — it travels as session state
+    # (report_language) and reaches the prompt through inject_report_language.
     report_config = ReportConfig()
     await manager._set_state("report_config", report_config.to_state())
 

--- a/CoScientist/web/session_bundle.py
+++ b/CoScientist/web/session_bundle.py
@@ -15,6 +15,7 @@ Bundle contents
     agent_events.json               — WebRuntime.agent_events log (chat + tool activity)
     metrics.json                    — WebRuntime.metrics (cost snapshot)
     dataset_url.json                — attached dataset URL
+    report_language.json            — report language chosen for the session
     settings_snapshot.json          — settings at export time (read-only, informational)
     graphs/execution.json           — execution graph snapshot
     graphs/research_active.json     — research graph snapshot
@@ -33,6 +34,8 @@ from pathlib import Path
 from typing import Any, Dict, Optional
 from uuid import uuid4
 
+from CoScientist.agents.callbacks.report_language import REPORT_LANGUAGES
+
 logger = logging.getLogger("CoScientist.web.session_bundle")
 
 BUNDLE_VERSION = 1
@@ -44,6 +47,7 @@ _ADK_SESSION = "adk_session.json"
 _AGENT_EVENTS = "agent_events.json"
 _METRICS = "metrics.json"
 _DATASET_URL = "dataset_url.json"
+_REPORT_LANGUAGE = "report_language.json"
 _SETTINGS = "settings_snapshot.json"
 _GRAPH_EXECUTION = "graphs/execution.json"
 _GRAPH_RESEARCH = "graphs/research_active.json"
@@ -106,6 +110,7 @@ async def export_session(
 
     # 5. Dataset URL
     dataset_url = runtime.dataset_urls.get(key, "")
+    report_language = runtime.report_languages.get(key, "")
 
     # 6. Settings snapshot
     settings_snapshot: Dict[str, Any] = {}
@@ -163,6 +168,9 @@ async def export_session(
         if metrics is not None:
             zf.writestr(_METRICS, _json_bytes(metrics))
         zf.writestr(_DATASET_URL, _json_bytes({"dataset_url": dataset_url}))
+        # No BUNDLE_VERSION bump: an older bundle without this member reads
+        # back as {}, and older code ignores a zip entry it does not know.
+        zf.writestr(_REPORT_LANGUAGE, _json_bytes({"report_language": report_language}))
         zf.writestr(_SETTINGS, _json_bytes(settings_snapshot))
         if execution_graph is not None:
             zf.writestr(_GRAPH_EXECUTION, _json_bytes(execution_graph))
@@ -219,6 +227,7 @@ async def import_session(
     agent_events = _read_json(_AGENT_EVENTS) or []
     metrics = _read_json(_METRICS)
     dataset_url_data = _read_json(_DATASET_URL) or {}
+    report_language_data = _read_json(_REPORT_LANGUAGE) or {}
     research_graph_data = _read_json(_GRAPH_RESEARCH)
     execution_graph_data = _read_json(_GRAPH_EXECUTION)
 
@@ -284,6 +293,17 @@ async def import_session(
     dataset_url = dataset_url_data.get("dataset_url", "")
     if dataset_url:
         runtime.dataset_urls[key] = dataset_url
+    report_language = report_language_data.get("report_language", "")
+    # A bundle is a file the user can edit, so it does not get to bypass the
+    # enum the socket enforces. An unknown value leaves the session with no
+    # choice, and the callback normalizer supplies the default.
+    if report_language in REPORT_LANGUAGES:
+        runtime.report_languages[key] = report_language
+    elif report_language:
+        logger.warning(
+            "Session bundle carries an unknown report language %r. Ignored.",
+            report_language,
+        )
 
     # --- Restore graphs ---
     _restore_graph_files(user_id, session_id, execution_graph_data, research_graph_data)

--- a/CoScientist/web/templates/index.html
+++ b/CoScientist/web/templates/index.html
@@ -356,6 +356,14 @@
               </button>
             </div>
           </div>
+          <!-- Report language for THIS session. Separate from the interface
+               language toggle (lang-btn-en / lang-btn-ru) in the sidebar. -->
+          <select id="report-lang-select" onchange="onReportLanguageChange()"
+            title="Report language / Язык отчёта"
+            class="shrink-0 bg-surface-container-highest border border-outline-variant/20 text-on-surface-variant text-[10px] font-mono rounded-md px-2 py-1 focus:border-primary/40 focus:ring-0 cursor-pointer">
+            <option value="ru" data-i18n="composer.reportLang.ru">Отчёт: RU</option>
+            <option value="en" data-i18n="composer.reportLang.en">Отчёт: EN</option>
+          </select>
           <textarea id="chat-input" rows="3" wrap="soft" spellcheck="false" autocomplete="off"
             class="bg-transparent border-none focus:ring-0 text-sm flex-1 py-1.5 text-on-surface placeholder:text-outline-variant/50 font-medium no-scrollbar"
             placeholder="Send system command…  (Enter — send, Shift+Enter — new line)"
@@ -444,6 +452,10 @@
       'nav.noUser': { en: 'No user selected', ru: 'Пользователь не выбран' },
       'nav.disconnected': { en: 'Disconnected', ru: 'Отключено' },
       'nav.orchestrator': { en: 'ORCHESTRATOR', ru: 'ОРКЕСТРАТОР' },
+
+      // ── Composer: report language (NOT the interface language) ──
+      'composer.reportLang.ru': { en: 'Report: RU', ru: 'Отчёт: RU' },
+      'composer.reportLang.en': { en: 'Report: EN', ru: 'Отчёт: EN' },
 
       // Agent descriptions in side nav
       'agent.OrchestratorAgent.desc': { en: 'Master Orchestrator', ru: 'Главный оркестратор' },
@@ -2333,6 +2345,7 @@
       clearChat();
       // Drop the previous session's attachment; the snapshot brings the new one.
       applyDatasetUrl('');
+      applyReportLanguage('');
       connect();
     }
 
@@ -2419,6 +2432,15 @@
 
       // The attachment belongs to the session the snapshot describes.
       applyDatasetUrl(snapshot.dataset_url);
+      // A session that already has a language keeps it. A fresh one adopts the
+      // interface language AND records it, so flipping the interface toggle
+      // later does not silently rewrite a report language already in use.
+      if (snapshot.report_language) {
+        applyReportLanguage(snapshot.report_language);
+      } else {
+        applyReportLanguage(currentLang);
+        sendReportLanguage(currentLang);
+      }
       updateCoderSandboxButton(null);
 
       for (const message of messages) {
@@ -2609,6 +2631,14 @@
             addSystemMsg('Dataset link rejected: ' + data.message);
             addTelemetry('DATASET :: rejected');
             break;
+          case 'report_language':
+            applyReportLanguage(data.report_language);
+            addTelemetry('REPORT LANG :: ' + data.report_language);
+            break;
+          case 'report_language_rejected':
+            addSystemMsg('Report language rejected: ' + data.message);
+            addTelemetry('REPORT LANG :: rejected');
+            break;
           case 'chat_accepted': {
             const input = document.getElementById('chat-input');
             if (input.value.trim() === String(data.message_text || '').trim()) {
@@ -2693,6 +2723,36 @@
     // is only a mirror of what the last snapshot/broadcast said.
     // =========================================================================
     let datasetUrl = '';
+
+    // Report language for the current session. Like the dataset link it lives
+    // on the SERVER, so this is only a mirror of the last snapshot/broadcast.
+    // '' means the server has no choice for this session yet.
+    let reportLanguage = '';
+
+    function applyReportLanguage(lang) {
+      reportLanguage = String(lang || '');
+      const select = document.getElementById('report-lang-select');
+      // With no server-side choice, show the interface language as the default.
+      if (select) select.value = reportLanguage || currentLang;
+    }
+
+    function sendReportLanguage(lang) {
+      if (!ws || ws.readyState !== 1) return false;
+      ws.send(JSON.stringify({ type: 'set_report_language', report_language: lang }));
+      return true;
+    }
+
+    function onReportLanguageChange() {
+      // Send only; the mirror is set when the server echoes, as with the dataset.
+      const select = document.getElementById('report-lang-select');
+      if (sendReportLanguage(select.value)) return;
+      // The socket is down, so the server never heard the pick. Put the select
+      // back to the language that is still in effect, or the report comes out
+      // in a language the UI no longer shows.
+      applyReportLanguage(reportLanguage);
+      addSystemMsg('Not connected — reconnect and try again.');
+      addTelemetry('REPORT LANG :: not sent, socket is down');
+    }
 
     function toggleAttachMenu(show) {
       const menu = document.getElementById('attach-menu');

--- a/tests/unit/test_report_language.py
+++ b/tests/unit/test_report_language.py
@@ -1,0 +1,96 @@
+"""Report language: the per-session parameter that drives the final report.
+
+The language reaches the Result Aggregator as ADK session state, not as a
+build-time constant, so these tests cover the two halves of that path: the
+callback that renders the block, and the prompt that carries the placeholder.
+"""
+import re
+
+from CoScientist.agents.callbacks.report_language import (
+    DEFAULT_REPORT_LANGUAGE,
+    REPORT_LANGUAGE_BLOCK_STATE_KEY,
+    REPORT_LANGUAGE_STATE_KEY,
+    inject_report_language,
+    normalize_report_language,
+)
+
+CYRILLIC = re.compile(r"[Ѐ-ӿ]")
+
+
+class _FakeContext:
+    """Stand-in for ADK's CallbackContext — the callback only touches .state."""
+
+    def __init__(self, state=None):
+        self.state = dict(state or {})
+
+
+def test_normalize_falls_back_for_anything_unsupported():
+    assert normalize_report_language("en") == "en"
+    assert normalize_report_language(" RU ") == "ru"
+    # A missing key, an empty value, and an unsupported code all collapse to the
+    # default, so the CLI and A2A paths keep the behavior they had before.
+    for bad in (None, "", "   ", "de", 7):
+        assert normalize_report_language(bad) == DEFAULT_REPORT_LANGUAGE
+
+
+def test_callback_renders_the_matching_block_and_returns_none():
+    for value, expected_marker in (
+        (None, "report in Russian"),
+        ("ru", "report in Russian"),
+        ("en", "report in English"),
+        ("de", "report in Russian"),
+    ):
+        state = {} if value is None else {REPORT_LANGUAGE_STATE_KEY: value}
+        context = _FakeContext(state)
+        # None keeps the agent's other before_agent callbacks running — ADK
+        # short-circuits its callback list on the first non-None result.
+        assert inject_report_language(context) is None
+        assert expected_marker in context.state[REPORT_LANGUAGE_BLOCK_STATE_KEY]
+
+
+def test_english_block_keeps_the_tool_generated_headings():
+    """format_results builds "## Figures" in code; English must not rewrite it."""
+    context = _FakeContext({REPORT_LANGUAGE_STATE_KEY: "en"})
+    inject_report_language(context)
+    block = context.state[REPORT_LANGUAGE_BLOCK_STATE_KEY]
+    assert "## Objective" in block
+    assert not CYRILLIC.search(block)
+
+    context = _FakeContext({REPORT_LANGUAGE_STATE_KEY: "ru"})
+    inject_report_language(context)
+    russian = context.state[REPORT_LANGUAGE_BLOCK_STATE_KEY]
+    assert "## Иллюстрации" in russian
+    assert "## Цель" in russian
+
+
+def test_callback_composes_with_the_research_context_callback():
+    """Both before_agent callbacks write to the SAME state, one after the other.
+
+    The aggregator runs inject_research_context then inject_report_language. If
+    either replaced .state instead of mutating it, the second write would drop
+    the first key and one of the prompt's two placeholders would render empty.
+    """
+    from CoScientist.graph.research.agent_tools import make_inject_research_context
+
+    context = _FakeContext({REPORT_LANGUAGE_STATE_KEY: "en"})
+    assert make_inject_research_context(is_root=False)(context) is None
+    assert inject_report_language(context) is None
+    assert "research_context" in context.state
+    assert "report in English" in context.state[REPORT_LANGUAGE_BLOCK_STATE_KEY]
+
+
+def test_aggregator_prompt_is_language_neutral():
+    """The regression guard: no language may be hardcoded back into the prompt.
+
+    The prompt must also keep its two state placeholders. A bare ``{key}``
+    without the ``?`` would raise KeyError mid-run on a session that predates
+    the key.
+    """
+    from CoScientist.agents import result_aggregator_agent
+
+    instruction = result_aggregator_agent.instruction
+    assert "{report_language_block?}" in instruction
+    assert "{research_context?}" in instruction
+    assert not CYRILLIC.search(instruction)
+    # A leftover build-time sentinel would mean render_template missed a value.
+    assert not re.search(r"<<[A-Z_]+>>", instruction)

--- a/tests/unit/test_web_sessions.py
+++ b/tests/unit/test_web_sessions.py
@@ -323,3 +323,62 @@ def test_dataset_link_is_validated_stored_and_broadcast_per_session():
             assert websocket.receive_json() == {"type": "dataset_url", "dataset_url": ""}
         assert key not in runtime.dataset_urls
         assert adk_session.state[web_app.DATASET_URL_STATE_KEY] == ""
+
+
+def test_report_language_is_validated_stored_and_broadcast_per_session():
+    """The composer's language picker: a closed enum, per session, on reconnect."""
+    app = create_app()
+    runtime = app.state.runtime
+    with TestClient(app) as client:
+        user = _create_user(client, "Gleb")
+        session = _create_session(client, user["id"], "Work")
+        other = _create_session(client, user["id"], "Other")
+        key = (user["id"], session["id"])
+        url = f"/ws?user_id={user['id']}&session_id={session['id']}"
+
+        with client.websocket_connect(url) as websocket:
+            websocket.receive_json()                       # connected
+            # Empty, not "ru": the server must not pick for the browser, or the
+            # UI default could never follow the interface language.
+            assert websocket.receive_json()["report_language"] == ""
+
+            # Anything outside the enum is refused before it reaches the session.
+            for bad in ("de", "russian", "en-US"):
+                websocket.send_json({
+                    "type": "set_report_language", "report_language": bad,
+                })
+                rejected = websocket.receive_json()
+                assert rejected["type"] == "report_language_rejected"
+                assert rejected["message"]
+            assert key not in runtime.report_languages
+
+            websocket.send_json({"type": "set_report_language", "report_language": "en"})
+            accepted = websocket.receive_json()
+            assert accepted == {"type": "report_language", "report_language": "en"}
+            assert runtime.report_languages[key] == "en"
+
+        # Mirrored into ADK state, where inject_report_language reads it.
+        adk_session = runtime.session_service.sessions[APP_NAME][user["id"]][session["id"]]
+        assert adk_session.state[web_app.REPORT_LANGUAGE_STATE_KEY] == "en"
+
+        # A reconnecting tab gets it back; a sibling session is unaffected.
+        with client.websocket_connect(url) as websocket:
+            websocket.receive_json()
+            assert websocket.receive_json()["report_language"] == "en"
+        with client.websocket_connect(
+            f"/ws?user_id={user['id']}&session_id={other['id']}"
+        ) as websocket:
+            websocket.receive_json()
+            assert websocket.receive_json()["report_language"] == ""
+
+        # Clearing drops the mirror and empties the agent-visible state, which
+        # hands the session back to the callback's default.
+        with client.websocket_connect(url) as websocket:
+            websocket.receive_json()
+            websocket.receive_json()
+            websocket.send_json({"type": "set_report_language", "report_language": ""})
+            assert websocket.receive_json() == {
+                "type": "report_language", "report_language": "",
+            }
+        assert key not in runtime.report_languages
+        assert adk_session.state[web_app.REPORT_LANGUAGE_STATE_KEY] == ""


### PR DESCRIPTION
## What this does

The Result Aggregator wrote the report in Russian for every user and every run.
The language is now a per-session parameter. The user picks it in the chat
composer from a closed enum: `ru` or `en`.

## How

An agent instruction is a plain string built once per session, so the language
cannot come from settings or a build-time template. It travels as ADK session
state instead, on the path the dataset URL already uses.

1. The composer sends `set_report_language` over the websocket.
2. `apply_report_language` writes `state['report_language']` with a `state_delta`.
3. The `inject_report_language` before_agent callback renders the matching block
   into `state['report_language_block']`.
4. The prompt reads it as `{report_language_block?}` at run time.

The callback injects the whole language contract, not a language name. The
section headings, the `format_results` heading substitutions, and the entity
glossary all differ by language. The English block mandates no substitutions, so
`## Figures` and `## Data tables` stay as the tool wrote them.

## Behavior change to know about

`DEFAULT_REPORT_LANGUAGE = "ru"` is now unreachable from the web UI. When a
session has no stored language, the browser sends the interface language. A user
with the interface set to EN gets an EN report where the previous behavior gave
RU. The `ru` default still covers the CLI and A2A entrypoints, which never set
the key and keep the behavior they have today.

## Scope

`ReportConfig` stays out of scope. It feeds `format_results`, not a prompt.
No agent other than the Result Aggregator changes.

## Files

| File | Change |
| --- | --- |
| `agents/callbacks/report_language.py` | New. The enum, the normalizer, the two language blocks, the callback. |
| `agents/callbacks/__init__.py` | Re-export. |
| `assembly/bindings.py` | Callback binding. |
| `agents/system.yaml` | `ResultAggregatorAgent.before_agent` gains the callback. |
| `agents/prompts/templates.py` | The aggregator prompt loses every Russian literal and defers to the block. |
| `web/app.py` | Validator, per-session mirror, `apply_report_language`, websocket branch, snapshot field, run-start re-sync. |
| `web/session_bundle.py` | `report_language.json`. Import checks the enum. |
| `web/templates/index.html` | The composer select, its JS, and the i18n keys. |

## Tests

`tests/unit/test_report_language.py` is new: 5 tests covering the normalizer
fallback, both blocks, composition with `inject_research_context`, and a guard
that the built prompt carries no Cyrillic.
`tests/unit/test_web_sessions.py` gains a per-session validate, store, and
broadcast test, modeled on the dataset URL test.

310 unit tests pass. Three fail: two in `test_hitl_agenttool_scope.py` and one in
`test_opik_tracer.py` that needs an API key. All three fail on a clean tree.