### PR TITLE
Feat: consume the S3 vault — sync, resolve, and promote

### DIFF
--- a/CoScientist/agents/system.yaml
+++ b/CoScientist/agents/system.yaml
@@ -337,7 +337,7 @@ agents:
           → Use whenever no existing tool covers the objective and the step requires
             doing software/data engineering rather than calling a ready service
     prompt: coder
-    tools: [coder, sandbox, research_graph]
+    tools: [coder, sandbox, research_graph, vault]
     subordinates: [DatasetCollectorAgent]
     output_key: coder_results
     callbacks:
@@ -380,7 +380,7 @@ agents:
       building or training on it (e.g. "collect a dataset of BTK inhibitors with
       IC50"). It downloads into the shared workspace and writes a MANIFEST.
     prompt: dataset_collector
-    tools: [coder, sandbox, websearch, research_graph]
+    tools: [coder, sandbox, websearch, research_graph, vault]
     output_key: dataset_results
     callbacks:
       before_agent: [inject_research_context, inject_dataset_context]

--- a/CoScientist/assembly/bindings.py
+++ b/CoScientist/assembly/bindings.py
@@ -36,6 +36,11 @@ def _papers_search():
     return papers_search_toolset_instance
 
 
+def _vault():
+    from CoScientist.tools import vault_toolset_instance
+    return vault_toolset_instance
+
+
 def _retrieval():
     from CoScientist.tools import retrieval_toolset_instance
     return retrieval_toolset_instance
@@ -196,6 +201,33 @@ REGISTRY.register_tool(ToolEntry(
             name="explore_my_papers",
             signature="explore_my_papers(question, s3_keys)",
             purpose="Answers questions using user-uploaded or previously downloaded papers.",
+        ),
+    ),
+))
+
+REGISTRY.register_tool(ToolEntry(
+    key="vault",
+    factory=_vault,
+    optional=True,  # built only when MCP__VAULT_URL is configured
+    runtime_resolved=True,
+    docs=(
+        ToolDoc(
+            name="get_upload_link",
+            signature="get_upload_link(filename, feature=None)",
+            purpose=(
+                "Returns a one-hour upload_url for a new file, plus the bucket "
+                "and s3_key that identify it for good. Upload with a plain HTTP "
+                "PUT and no extra headers. Report the bucket and the s3_key, "
+                "never the URL: the URL expires and the object does not."
+            ),
+        ),
+        ToolDoc(
+            name="get_download_link",
+            signature="get_download_link(s3_key)",
+            purpose=(
+                "Turns an s3_key from an earlier step back into a one-hour "
+                "download URL. Use it when a link you were given no longer works."
+            ),
         ),
     ),
 ))

--- a/CoScientist/config/settings.py
+++ b/CoScientist/config/settings.py
@@ -152,6 +152,11 @@ class MCPSettings(BaseModel):
     paper_analysis_url: Optional[str] = None
     papers_search_url: Optional[str] = None
     result_formatter_url: Optional[str] = None
+    # The file vault (mcp-servers/vault-mcp-server). Two consumers read it:
+    # worker agents get the upload/download pair as an ADK toolset, and
+    # framework code calls it per request through tools/vault_client.py.
+    # Unset means both drop out, and the run still completes.
+    vault_url: Optional[str] = None
 
 
 # =========================

--- a/CoScientist/examples/example_config.env
+++ b/CoScientist/examples/example_config.env
@@ -82,6 +82,10 @@ COLLECTIONS__IMAGES=your-name-here
 # =========================
 # S3
 # =========================
+# These keys belong to the paper parser (CoScientist/paper_parser). They are
+# NOT the vault configuration. The vault reads its own S3__* keys from
+# mcp-servers/vault-mcp-server/.env. The names repeat, the consumers differ.
+# CoScientist itself never talks to S3 with a key. It calls the vault over MCP.
 S3__USE_S3=True
 S3__ENDPOINT_URL=http://0.0.0.0:9000
 S3__ACCESS_KEY=username
@@ -102,6 +106,15 @@ OPIK__PROJECT_NAME=your-project-name
 # =========================
 MCP__PAPER_ANALYSIS_URL=
 MCP__PAPERS_SEARCH_URL=
+MCP__RESULT_FORMATTER_URL=
+
+# The file vault (mcp-servers/vault-mcp-server), on host port 7338. Two
+# consumers read it: worker agents get the upload and download pair as a
+# toolset, and framework code calls it per request to mint a fresh download
+# link and to promote report artifacts out of ephemeral/.
+# Leave it empty and both drop out. A run still completes, and every artifact
+# stays under ephemeral/, where the lifecycle rule deletes it.
+MCP__VAULT_URL=
 
 
 

--- a/CoScientist/reporting/collect.py
+++ b/CoScientist/reporting/collect.py
@@ -7,6 +7,7 @@ it knows nothing about any specific paper or task, only about *artifacts*.
 """
 from __future__ import annotations
 
+import json
 import logging
 import os
 import re
@@ -14,9 +15,10 @@ import shutil
 import urllib.parse
 import uuid
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional, Set
 
 from CoScientist.reporting.artifact_index import load as load_artifact_index
+from CoScientist.utils.s3_refs import s3_uri
 
 logger = logging.getLogger(__name__)
 
@@ -36,6 +38,13 @@ _WORKSPACE_SKIP_DIRS = frozenset({
     ".ipynb_checkpoints", "build", "dist",
 })
 _MAX_WORKSPACE_FILES = 40
+
+# Where a collected file came from, written beside the report folder for
+# finalize_report. Collection knows the bucket and the key and then throws
+# them away for a local path, and finalize runs later and needs them back to
+# promote the object out of ephemeral/. Dot-prefixed: it is plumbing between
+# two stages, not part of the deliverable.
+SOURCES_FILENAME = ".artifact_sources.json"
 
 # Any http(s) URL whose path ends in a known media extension (the presigned query
 # string is optional). Bulletproof fallback: matches an artifact link embedded in
@@ -179,6 +188,8 @@ def collect_artifacts(
     workspace_root: Path | str = "workspace",
     graph_nodes: Optional[List[Dict[str, Any]]] = None,
     index_key: Optional[tuple] = None,
+    resolve_url: Optional[Callable[[str], Optional[str]]] = None,
+    synced_files: Optional[Set[str]] = None,
 ) -> Dict[str, Any]:
     """Copy/download run artifacts into the report folder; return markdown blocks.
 
@@ -198,6 +209,18 @@ def collect_artifacts(
                        an AgentTool child the raw session id is a transient
                        random one, while the index keeps the public web scope.
                        Without it the index is found by ``session_id`` alone.
+        resolve_url:   turns an ``s3://bucket/key`` into a fresh download URL.
+                       A presigned URL cached in the index expires in an hour,
+                       so a run that is restarted, or simply slow, arrives here
+                       holding dead links. This function is called for those.
+                       ``None`` leaves them unresolved, as before.
+        synced_files:  workspace-relative paths the vault sync already uploaded.
+                       Those arrive through the index, so the walk below skips
+                       them. Without this they would be collected twice whenever
+                       the code-exec server runs on this host, because both sides
+                       use ``code_exec.workspace_root``. A file the sync failed
+                       to upload is NOT in this set and is still walked, which is
+                       the point of naming them instead of skipping the walk.
 
     Returns a dict with ``report_dir``, ``figures``, ``tables``, and
     ``blocks_markdown`` (the concatenation the agent should embed).
@@ -232,18 +255,49 @@ def collect_artifacts(
         for url in find_artifact_urls(node.get("attrs") or {}):
             artifact_lists.append({"url": url, "tool": label or "graph"})
     seen_urls = set()
+    seen_refs = set()
     unresolved = 0
+    sources: Dict[str, Dict[str, str]] = {}
+
+    def _fresh_url(art: Dict[str, Any]) -> Optional[str]:
+        """A download URL for this artifact, minted from the durable reference
+        when the cached one is missing or dead."""
+        bucket, key = art.get("bucket"), art.get("s3_key")
+        if not (resolve_url and bucket and key):
+            return None
+        try:
+            return resolve_url(s3_uri(bucket, key))
+        except Exception as exc:  # noqa: BLE001 - a report outranks one figure
+            logger.warning("collect: cannot resolve s3://%s/%s (%s)", bucket, key, exc)
+            return None
+
+    def _note_source(art: Dict[str, Any], dest: Path) -> None:
+        """Remember which object this local file came from, for finalize."""
+        bucket, key = art.get("bucket"), art.get("s3_key")
+        if bucket and key:
+            sources[_rel(dest, report_dir)] = {"bucket": bucket, "s3_key": key}
+
     for art in artifact_lists:
+        # Dedupe on the durable reference where there is one. Two entries for one
+        # object can hold two different presigned URLs and still be one file.
+        bucket, key = art.get("bucket"), art.get("s3_key")
+        ref = s3_uri(bucket, key) if bucket and key else None
+        if ref:
+            if ref in seen_refs:
+                continue
+            seen_refs.add(ref)
+
         url = art.get("url")
-        # A durable reference whose cached URL is gone or dead. It needs the
-        # vault get_download_link to become a file again, which is the next
-        # branch. Count it, so the gap shows up in the log.
-        if not url:
-            if art.get("s3_key"):
-                unresolved += 1
-            continue
-        if url in seen_urls:
-            continue
+        if not url or url in seen_urls:
+            # No URL at all, or one already spent on an earlier entry. A durable
+            # reference can still produce a working link.
+            if url and not ref:
+                continue
+            url = _fresh_url(art) or url
+            if not url:
+                if art.get("s3_key"):
+                    unresolved += 1
+                continue
         seen_urls.add(url)
         if _looks_like(url, _SOURCE_EXTS):
             continue
@@ -251,27 +305,37 @@ def collect_artifacts(
         if _looks_like(url, _IMAGE_EXTS):
             name = f"{label}_{_url_filename(url, '.png')}"
             dest = figures_dir / name
-            if _download(url, dest):
-                figures.append(str(dest))
-                figure_blocks.append(f"### {label}\n\n![{label}](figures/{name})")
-            elif art.get("s3_key"):
-                unresolved += 1
+            if not _download(url, dest):
+                # The cached URL expired. Mint one and try once more.
+                retry = _fresh_url(art)
+                if not (retry and retry != url and _download(retry, dest)):
+                    if art.get("s3_key"):
+                        unresolved += 1
+                    continue
+            figures.append(str(dest))
+            figure_blocks.append(f"### {label}\n\n![{label}](figures/{name})")
+            _note_source(art, dest)
         else:  # default remote artifacts to tabular
             name = f"{label}_{_url_filename(url, '.csv')}"
             dest = tables_dir / name
-            if _download(url, dest):
-                tables.append(str(dest))
-                md = _table_to_markdown(dest)
-                head = f"### {label} — [download]({_rel(dest, report_dir)})"
-                table_blocks.append(f"{head}\n\n{md}" if md else head)
-            elif art.get("s3_key"):
-                unresolved += 1
+            if not _download(url, dest):
+                retry = _fresh_url(art)
+                if not (retry and retry != url and _download(retry, dest)):
+                    if art.get("s3_key"):
+                        unresolved += 1
+                    continue
+            tables.append(str(dest))
+            md = _table_to_markdown(dest)
+            head = f"### {label} — [download]({_rel(dest, report_dir)})"
+            table_blocks.append(f"{head}\n\n{md}" if md else head)
+            _note_source(art, dest)
 
     # 2) Files the run itself LEFT in the sandbox workspace. Prune vendored trees
     #    aggressively: a coder step may `git clone` a whole library (e.g. the RDKit
     #    repo) or create a venv into the sandbox, and its bundled example
     #    images/CSVs are NOT run outputs — collecting them buries the real figures.
     workspace_dir = Path(workspace_root) / f"ws_{session_id}"
+    already_synced = synced_files or set()
     ws_figures = ws_tables = 0
     if workspace_dir.exists():
         for root, dirs, files in os.walk(workspace_dir):
@@ -287,6 +351,8 @@ def collect_artifacts(
             ]
             for fname in sorted(files):
                 src = Path(root) / fname
+                if _rel(src, workspace_dir) in already_synced:
+                    continue  # the vault sync sent this one; it comes back above
                 stem = src.stem
                 if _looks_like(fname, _IMAGE_EXTS):
                     if ws_figures >= _MAX_WORKSPACE_FILES:
@@ -316,6 +382,18 @@ def collect_artifacts(
         (sections_dir / "tables.md").write_text(
             "## Data tables\n\n" + "\n\n".join(table_blocks) + "\n", encoding="utf-8"
         )
+
+    # 4) Where each collected file came from. finalize_report reads this to
+    #    promote the objects out of ephemeral/ before the lifecycle rule takes
+    #    them. It goes on disk rather than into session state because one of the
+    #    two finalize call sites (web/app.py) passes no state at all.
+    if sources:
+        try:
+            (report_dir / SOURCES_FILENAME).write_text(
+                json.dumps(sources, indent=2), encoding="utf-8"
+            )
+        except Exception as exc:  # noqa: BLE001 - promotion is not the report
+            logger.warning("collect: failed to write %s (%s)", SOURCES_FILENAME, exc)
 
     blocks: List[str] = []
     if figure_blocks:
@@ -354,4 +432,4 @@ def _rel(path: Path, base: Path) -> str:
         return path.name
 
 
-__all__ = ["collect_artifacts", "report_dir_for"]
+__all__ = ["collect_artifacts", "report_dir_for", "SOURCES_FILENAME"]

--- a/CoScientist/reporting/finalize.py
+++ b/CoScientist/reporting/finalize.py
@@ -14,7 +14,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from CoScientist.config.report import ReportConfig
-from CoScientist.reporting.collect import report_dir_for
+from CoScientist.reporting.collect import SOURCES_FILENAME, report_dir_for
 from CoScientist.reporting.latex import render_latex
 
 logger = logging.getLogger(__name__)
@@ -53,7 +53,10 @@ def finalize_report(
         latex_files = render_latex(
             final_markdown or "", report_dir, report_config.latex, references
         )
-        manifest = _build_manifest(session_id, report_dir, report_config, latex_files)
+        promoted = _promote_sources(report_dir)
+        manifest = _build_manifest(
+            session_id, report_dir, report_config, latex_files, promoted
+        )
         (report_dir / "MANIFEST.json").write_text(
             json.dumps(manifest, indent=2), encoding="utf-8"
         )
@@ -64,11 +67,64 @@ def finalize_report(
         return RunResult(markdown=final_markdown, report_dir=None, manifest=None)
 
 
+def _promote_sources(report_dir: Path) -> Dict[str, str]:
+    """Copy every collected artifact out of ``ephemeral/`` and into ``permanent/``.
+
+    A worker only ever uploads under ``ephemeral/``, where the bucket lifecycle
+    rule deletes it after EPHEMERAL_TTL_DAYS. The report outlives that, so the
+    objects it shows have to move. ``collect_artifacts`` left the mapping from
+    each local file to its object in ``SOURCES_FILENAME``.
+
+    Only objects that S3 already holds are promoted. ``report.md``, the LaTeX
+    output, and the files a local sandbox left on this disk were never uploaded,
+    and a worker may not write to ``permanent/`` directly.
+
+    Returns report-relative path -> new ``permanent/`` key. Empty on any failure:
+    a vault that is down costs the deliverable its durability, not its existence.
+    """
+    sources_path = report_dir / SOURCES_FILENAME
+    if not sources_path.exists():
+        return {}
+    try:
+        sources = json.loads(sources_path.read_text(encoding="utf-8"))
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("report: cannot read %s (%s)", sources_path, exc)
+        return {}
+    # A stale or hand-edited file can hold any shape. Check it here: an escape
+    # from this function lands in the caller's except, which reports the whole
+    # deliverable as missing while report.md sits complete on disk.
+    if not isinstance(sources, dict):
+        logger.warning("report: %s is not a mapping, skipping promotion", sources_path)
+        return {}
+
+    from CoScientist.tools.vault_client import call_vault_sync, vault_url
+
+    if not vault_url():
+        logger.info("report: MCP__VAULT_URL is not set, artifacts stay ephemeral")
+        return {}
+
+    promoted: Dict[str, str] = {}
+    for rel_path, ref in sorted(sources.items()):
+        key = ref.get("s3_key") if isinstance(ref, dict) else None
+        if not isinstance(key, str) or not key.startswith("ephemeral/"):
+            continue
+        result = call_vault_sync("promote_artifact", s3_key=key)
+        new_key = (result or {}).get("s3_key")
+        if new_key:
+            promoted[rel_path] = new_key
+        else:
+            logger.warning("report: could not promote %s for %s", key, rel_path)
+
+    logger.info("report: promoted %d of %d artifact(s)", len(promoted), len(sources))
+    return promoted
+
+
 def _build_manifest(
     session_id: str,
     report_dir: Path,
     report_config: ReportConfig,
     latex_files: List[Path],
+    promoted: Optional[Dict[str, str]] = None,
 ) -> Dict[str, Any]:
     def listing(subdir: str) -> List[str]:
         d = report_dir / subdir
@@ -83,6 +139,9 @@ def _build_manifest(
         "figures": listing("figures"),
         "tables": listing("tables"),
         "sections": listing("sections"),
+        # Report-relative path -> the permanent/ key that outlives the run. A
+        # file with no entry here exists only inside this folder.
+        "promoted": promoted or {},
         "latex": {
             "mode": report_config.latex,
             "files": sorted(str(p.relative_to(report_dir)) for p in latex_files),

--- a/CoScientist/tools/__init__.py
+++ b/CoScientist/tools/__init__.py
@@ -4,7 +4,12 @@
 import CoScientist.tools.mcp_patches  # noqa: F401
 
 from CoScientist.tools.fedotmas_tools import FedotMASToolset, fedot_toolset_instance
-from CoScientist.tools.research_tools import websearch_toolset_instance, paper_analysis_toolset_instance, papers_search_toolset_instance
+from CoScientist.tools.research_tools import (
+    websearch_toolset_instance,
+    paper_analysis_toolset_instance,
+    papers_search_toolset_instance,
+    vault_toolset_instance,
+)
 from CoScientist.tools.retrieval_tools import RetrievalToolSet, retrieval_toolset_instance
 from CoScientist.tools.servers_web_search import search_mcp_servers
 from CoScientist.tools.med_tools import med_toolset_instance
@@ -26,6 +31,7 @@ __all__ = [
     "websearch_toolset_instance",
     "paper_analysis_toolset_instance",
     "papers_search_toolset_instance",
+    "vault_toolset_instance",
     "RetrievalToolSet",
     "retrieval_toolset_instance",
     "search_mcp_servers",

--- a/CoScientist/tools/mcp_artifact_plugin.py
+++ b/CoScientist/tools/mcp_artifact_plugin.py
@@ -22,12 +22,22 @@ from typing import Any
 from google.adk.plugins import BasePlugin
 
 from CoScientist.reporting.artifact_index import record
-from CoScientist.reporting.collect import find_artifact_urls
+from CoScientist.reporting.collect import (
+    _IMAGE_EXTS,
+    _TABLE_EXTS,
+    _looks_like,
+    find_artifact_urls,
+)
 from CoScientist.utils.s3_refs import find_s3_artifacts
 
 logger = logging.getLogger(__name__)
 
 _STATE_KEY = "mcp_artifacts"
+
+
+def _is_report_artifact(key: str) -> bool:
+    """Whether this object belongs in a report at all."""
+    return _looks_like(key, _IMAGE_EXTS + _TABLE_EXTS)
 
 
 class McpArtifactCapturePlugin(BasePlugin):
@@ -74,6 +84,11 @@ class McpArtifactCapturePlugin(BasePlugin):
     def _record_index(tool, tool_context, urls, artifacts) -> None:
         """Append this call's artifacts to the on-disk index of the session."""
         tool_name = getattr(tool, "name", None)
+        # An upload link is a PUT capability. It cannot fetch the object, and the
+        # object may not even exist yet — the agent was only handed somewhere to
+        # put one. Keep the reference, drop the URL, and let the collector mint a
+        # download link once there is something to download.
+        is_upload = tool_name == "get_upload_link"
         entries = [
             {
                 "bucket": a["bucket"],
@@ -82,9 +97,13 @@ class McpArtifactCapturePlugin(BasePlugin):
                 "label": a["s3_key"].rsplit("/", 1)[-1],
                 # A capability with an expiry, kept so the report can download
                 # inside the same run. The bucket and key above are the reference.
-                "url": a.get("url"),
+                "url": None if is_upload else a.get("url"),
             }
             for a in artifacts
+            # A worker parks whatever it likes in the vault — a checkpoint, a
+            # pickle. The report holds figures and tables, and an unknown
+            # extension there is collected as a table.
+            if not is_upload or _is_report_artifact(a["s3_key"])
         ]
         # A server that returns a bare presigned URL and no key. Keep the URL so
         # nothing is lost, and change 2 gives these servers the full contract.

--- a/CoScientist/tools/research_tools.py
+++ b/CoScientist/tools/research_tools.py
@@ -10,6 +10,7 @@ from CoScientist.utils.selective_proxy import create_mcp_proxy_httpx_factory
 settings = get_settings()
 PAPER_ANALYSIS_URL = settings.mcp.paper_analysis_url
 PAPERS_SEARCH_URL = settings.mcp.papers_search_url
+VAULT_URL = settings.mcp.vault_url
 
 
 _PAPER_ANALYSIS_TIMEOUT = 60 * 15.0  # 30 min — processing many PDFs is slow
@@ -18,12 +19,16 @@ def _http_mcp_toolset(
     url: Optional[str],
     sse_read_timeout: float = 60 * 5.0,
     headers: Optional[dict] = None,
+    tool_filter: Optional[list] = None,
 ) -> Optional[McpToolset]:
     """Build an HTTP MCP toolset, or None when the URL is not configured.
 
     Returning None (instead of crashing at import on a missing URL) lets the app
     start without these optional services; the ResearchAgent simply runs without
     the corresponding toolset. Set the URLs in .env to enable them.
+
+    ``tool_filter`` names the tools to keep. A server may expose more than an
+    agent should see (see the vault below).
     """
     if not url:
         return None
@@ -32,7 +37,8 @@ def _http_mcp_toolset(
             url=url,
             sse_read_timeout=sse_read_timeout,
             headers=headers or {},
-        )
+        ),
+        tool_filter=tool_filter,
     )
 
 
@@ -68,3 +74,20 @@ _openalex_headers = {
     if v
 }
 papers_search_toolset_instance = _http_mcp_toolset(PAPERS_SEARCH_URL, headers=_openalex_headers)
+
+
+# ---------------------------------------------------------------------------
+# The file vault — worker surface only
+# ---------------------------------------------------------------------------
+# The server also exposes promote_artifact, cleanup_session,
+# update_artifact_metadata, get_session_manifest and list_artifacts. Those are
+# framework tools: they promote, delete, or read across a whole session. An
+# agent gets the two that move one file, and nothing else. Framework code calls
+# the rest through tools/vault_client.py, which does not go through an agent.
+#
+# get_upload_link and get_download_link both declare user_id / session_id, so
+# SessionScopePlugin fills them at the tool boundary and the model never
+# supplies a scope.
+VAULT_WORKER_TOOLS = ["get_upload_link", "get_download_link"]
+
+vault_toolset_instance = _http_mcp_toolset(VAULT_URL, tool_filter=VAULT_WORKER_TOOLS)

--- a/CoScientist/tools/result_formatter_tool.py
+++ b/CoScientist/tools/result_formatter_tool.py
@@ -7,8 +7,9 @@ workspace directly; it needs no running container.
 """
 from __future__ import annotations
 
+import asyncio
 import logging
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 from google.adk.tools import FunctionTool
 from google.adk.tools.tool_context import ToolContext
@@ -16,6 +17,9 @@ from google.adk.tools.tool_context import ToolContext
 from CoScientist.config.report import ReportConfig
 from CoScientist.graph.session_scope import session_key
 from CoScientist.reporting.collect import collect_artifacts
+from CoScientist.tools.vault_client import call_vault_sync
+from CoScientist.tools.workspace_sync import sync_workspace_to_s3
+from CoScientist.utils.s3_refs import split_s3_uri
 
 logger = logging.getLogger(__name__)
 
@@ -61,6 +65,30 @@ def _state_to_dict(state: Any) -> Dict[str, Any]:
         return dict(getattr(state, "_value", {}) or {})
 
 
+def _download_link(uri: str) -> Optional[str]:
+    """A fresh download URL for an ``s3://bucket/key``.
+
+    A presigned URL lives one hour. The index caches the one that came back with
+    the artifact, so a long run — or one that was restarted — reaches the report
+    holding dead links. The object is still there, and the vault mints a new URL
+    for it.
+
+    ``collect_artifacts`` stays synchronous, so this cannot await. The whole
+    collection runs in a worker thread instead (see below), which is why
+    ``call_vault_sync`` is safe here: that thread has no running loop.
+
+    The vault resolves the key against its own bucket, and ``get_download_link``
+    takes no bucket. A deployment runs one bucket, so this holds. An artifact
+    from a server pointed at a different bucket would resolve to nothing, and
+    the vault reports that as an error the caller logs.
+    """
+    split = split_s3_uri(uri)
+    if not split:
+        return None
+    result = call_vault_sync("get_download_link", s3_key=split[1])
+    return (result or {}).get("presigned_url")
+
+
 async def format_results(tool_context: ToolContext) -> Dict[str, Any]:
     """Collect every figure and data table this run produced into the report
     folder and return markdown blocks (image embeds + tables) to embed verbatim
@@ -69,7 +97,21 @@ async def format_results(tool_context: ToolContext) -> Dict[str, Any]:
     session_id = _session_id(tool_context)
     cfg = ReportConfig.from_mapping(state.get("report_config"))
 
-    result = collect_artifacts(
+    # With a remote code-exec host the sandbox files are not on this disk, so
+    # collect_artifacts would find nothing there. Push them to S3 first. This has
+    # to run BEFORE collection, not at finalize: a figure reaches the report only
+    # through the call below.
+    synced = set()
+    try:
+        synced = await sync_workspace_to_s3(tool_context, state)
+    except Exception as exc:  # noqa: BLE001 - a failed sync must not stop a report
+        logger.warning("format_results: workspace sync failed (%s)", exc)
+
+    # Off the event loop. Collection downloads every artifact over the network,
+    # and each dead link costs a vault round trip on top. On the loop thread all
+    # of that would stall every other agent and every open websocket.
+    result = await asyncio.to_thread(
+        collect_artifacts,
         session_id=session_id,
         state=state,
         reports_root=cfg.reports_root,
@@ -77,6 +119,12 @@ async def format_results(tool_context: ToolContext) -> Dict[str, Any]:
         # The capture plugin writes the index under the same scope the graph
         # uses, which is the public web session even inside an AgentTool child.
         index_key=session_key(tool_context),
+        resolve_url=_download_link,
+        # What the sync uploaded arrives through the artifact index. The walk
+        # would find the same files again whenever the code-exec server runs on
+        # this host, because both sides use code_exec.workspace_root. Naming them
+        # keeps a file whose upload failed reachable from disk.
+        synced_files=synced,
     )
     logger.info(
         "format_results: session=%s figures=%d tables=%d",

--- a/CoScientist/tools/vault_client.py
+++ b/CoScientist/tools/vault_client.py
@@ -1,0 +1,107 @@
+"""A per-call MCP client for the file vault, for framework code only.
+
+Worker agents reach the vault through an ADK ``McpToolset`` (see
+``research_tools.py``). This module is the other consumer: plain framework code
+that has an ``s3://bucket/key`` and needs a file, or has an ``ephemeral/`` key
+and needs it promoted. Report packaging and the workspace sync both run outside
+any agent, so neither can use a toolset.
+
+Every call opens its own session and closes it. The ADK session manager caches a
+session and binds its exit stack to the loop that created it, so a shared
+instance driven from a fresh loop fails on the second call. The raw MCP SDK has
+no such state.
+
+No function here raises. A missing URL, an unreachable server, or a vault error
+all return ``None`` and log a warning. A run that produced results must still
+produce a report.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from typing import Any, Dict, Optional
+
+from CoScientist.config import get_settings
+
+logger = logging.getLogger(__name__)
+
+# One vault call moves no payload, only a key and a URL. The object itself
+# travels straight to S3, so the server answers fast or it is down.
+_TIMEOUT = 30.0
+
+
+def vault_url() -> Optional[str]:
+    """Read at call time, so a test can point this at a local server."""
+    return get_settings().mcp.vault_url
+
+
+def _payload(result: Any) -> Optional[Dict[str, Any]]:
+    """Unwrap the vault reply.
+
+    Every vault tool returns a JSON string, and MCP wraps it again in
+    ``content[].text``. The same double envelope ``utils/s3_refs.py`` walks.
+    """
+    for item in getattr(result, "content", None) or []:
+        text = getattr(item, "text", None)
+        if not isinstance(text, str):
+            continue
+        try:
+            data = json.loads(text)
+        except (ValueError, TypeError):
+            continue
+        if isinstance(data, dict):
+            return data
+    return None
+
+
+async def call_vault(tool_name: str, **args: Any) -> Optional[Dict[str, Any]]:
+    """Call one vault tool. Return its payload, or None."""
+    url = vault_url()
+    if not url:
+        logger.debug("vault: MCP__VAULT_URL is not set, skipping %s", tool_name)
+        return None
+
+    # Imported here so that loading this module does not pull the MCP stack into
+    # a process that never calls the vault.
+    from mcp import ClientSession
+    from mcp.client.streamable_http import streamablehttp_client
+
+    try:
+        async with streamablehttp_client(url, timeout=_TIMEOUT) as (read, write, _):
+            async with ClientSession(read, write) as session:
+                await session.initialize()
+                result = await session.call_tool(tool_name, args)
+    except Exception as exc:  # noqa: BLE001 - the vault must never sink a run
+        logger.warning("vault: %s failed (%s)", tool_name, exc)
+        return None
+
+    payload = _payload(result)
+    if payload is None:
+        logger.warning("vault: %s returned no readable payload", tool_name)
+        return None
+    # The vault reports a refusal in the body, not as a transport error.
+    if payload.get("error"):
+        logger.warning("vault: %s refused (%s)", tool_name, payload["error"])
+        return None
+    return payload
+
+
+def call_vault_sync(tool_name: str, **args: Any) -> Optional[Dict[str, Any]]:
+    """The same call from synchronous code.
+
+    ``finalize_report`` is the caller. Both of its call sites reach it through
+    ``asyncio.to_thread``, so the worker thread has no running loop and
+    ``asyncio.run`` is safe. Refuse when a loop IS running: calling this from
+    the event-loop thread would deadlock it, and ``call_vault`` is right there.
+    """
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(call_vault(tool_name, **args))
+    raise RuntimeError(
+        f"call_vault_sync({tool_name!r}) ran on the event loop. Await call_vault instead."
+    )
+
+
+__all__ = ["call_vault", "call_vault_sync", "vault_url"]

--- a/CoScientist/tools/workspace_sync.py
+++ b/CoScientist/tools/workspace_sync.py
@@ -1,0 +1,228 @@
+"""Push the remote sandbox workspace into S3 at the end of a run.
+
+``collect_artifacts`` walks ``workspace/ws_<session>`` on the local disk. With
+``CODE_EXEC__URL`` set, the files sit on the code-exec host instead, the walk
+finds nothing, and the report loses every figure the run drew.
+
+The code-exec API is submit and result only. It cannot serve a file. So the file
+has to leave from the inside: the framework mints a presigned PUT link with the
+vault, and the sandbox uploads to S3 with it. The vault itself stays private to
+CoScientist — the signed URL points at S3.
+
+The upload runs through ``python3`` and ``urllib``, not ``curl``. The code-exec
+image (``docker/Dockerfile``) is ``python:3.12-slim`` plus build-essential, vim
+and git. It has no curl, and it always has python3.
+
+Nothing here raises. A sync that fails leaves the report exactly as it is today.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import re
+import shlex
+from typing import Any, Dict, List, Optional, Set
+
+from CoScientist.config import get_settings
+from CoScientist.reporting import artifact_index
+from CoScientist.reporting.collect import (
+    _IMAGE_EXTS,
+    _MAX_WORKSPACE_FILES,
+    _TABLE_EXTS,
+    _WORKSPACE_SKIP_DIRS,
+    _looks_like,
+)
+from CoScientist.graph.session_scope import session_key
+from CoScientist.tools.session_scope_plugin import _safe_id
+from CoScientist.tools.vault_client import call_vault, vault_url
+
+logger = logging.getLogger(__name__)
+
+# The same key the CoderToolset pins its sandbox under. Read it, never mint one:
+# no id in state means no coder step ran, and there is nothing to sync.
+_WORKSPACE_STATE_KEY = "coder_workspace_id"
+
+# The vault filename rule: ^[a-zA-Z0-9_.-]{1,128}$ (vault_server._FILENAME_RE).
+_FILENAME_SUB = re.compile(r"[^a-zA-Z0-9_.-]+")
+_MAX_FILENAME = 128
+
+_LIST_TIMEOUT = 30
+_UPLOAD_TIMEOUT = 180
+
+# Read the file, PUT it, print nothing. No headers: the vault deliberately signs
+# no content type, so any header it did not sign would break the signature.
+_PUT_SNIPPET = (
+    "import sys,urllib.request;"
+    "d=open(sys.argv[1],'rb').read();"
+    "r=urllib.request.Request(sys.argv[2],data=d,method='PUT');"
+    "urllib.request.urlopen(r,timeout=120)"
+)
+
+
+def _workspace_id(state: Dict[str, Any]) -> Optional[str]:
+    """The sandbox this session used, by the same priority the CoderToolset uses.
+
+    Note this is NOT ``ws_<session_id>``. Every CoderAgent delegation runs in its
+    own AgentTool sub-session with a random id, so the toolset pins one id in
+    session state and reuses it. Reading the session id here would name a
+    workspace that never existed.
+    """
+    # An explicit pin (the A2A shared workspace) wins, from either source, and
+    # the toolset never writes it to state. Reading state alone would miss it.
+    fixed = get_settings().web.coder_workspace_id or os.getenv("CODER_WORKSPACE_ID")
+    if fixed:
+        return f"ws_{re.sub(r'[^A-Za-z0-9_-]', '', fixed)[:48] or 'shared'}"
+    existing = state.get(_WORKSPACE_STATE_KEY)
+    return str(existing) if existing else None
+
+
+def _flatten(rel_path: str) -> str:
+    """``plots/loss.png`` -> ``plots_loss.png``.
+
+    The vault key is ``ephemeral/<user>/<session>/workspace/<filename>``. A
+    sandbox often holds two files with one basename (``plots/loss.png`` and
+    ``runs/2/loss.png``), and a bare basename would let the second upload
+    overwrite the first. The vault regex does accept a slash here, but a nested
+    key would put the workspace two levels deep for no gain.
+
+    The result must match the vault filename rule, ``^[a-zA-Z0-9_.-]{1,128}$``.
+    A sandbox writes names the rule rejects — ``roc curve (fold 1).png`` — and
+    the vault answers with an error the caller can only log.
+    """
+    flat = _FILENAME_SUB.sub("_", rel_path.lstrip("./").replace("/", "_")).strip("_")
+    if len(flat) <= _MAX_FILENAME:
+        return flat or "artifact"
+    # Keep the extension: the report sorts a figure from a table by it.
+    stem, dot, ext = flat.rpartition(".")
+    if dot and len(ext) < 16:
+        return stem[: _MAX_FILENAME - len(ext) - 1] + "." + ext
+    return flat[:_MAX_FILENAME]
+
+
+def _is_pruned(rel_path: str, repo_roots: List[str]) -> bool:
+    parts = rel_path.split("/")
+    if any(p in _WORKSPACE_SKIP_DIRS for p in parts):
+        return True
+    if any(p.endswith((".dist-info", ".egg-info")) for p in parts):
+        return True
+    # A cloned repo brings its own example images. collect.py drops the whole
+    # subtree when it sees a .git inside, and so does this.
+    return any(rel_path.startswith(root + "/") for root in repo_roots)
+
+
+async def _list_files(toolset, workspace_id: str) -> List[str]:
+    """Every figure and table in the sandbox, workspace-relative, pruned."""
+    repos = await toolset._run_sync(
+        "find . -type d -name .git 2>/dev/null", workspace_id, max_wait=_LIST_TIMEOUT
+    )
+    if repos.get("status") != "success":
+        # Without this list nothing prunes a cloned library, and its bundled
+        # example images would fill the report. Sync nothing rather than that.
+        logger.warning("workspace sync: cannot probe %s for repositories (%s)",
+                       workspace_id, repos.get("stderr"))
+        return []
+    repo_roots = [
+        line.rstrip("/").removesuffix("/.git").lstrip("./")
+        for line in (repos.get("stdout") or "").splitlines()
+        if line.strip()
+    ]
+
+    listed = await toolset._run_sync(
+        "find . -type f 2>/dev/null", workspace_id, max_wait=_LIST_TIMEOUT
+    )
+    if listed.get("status") != "success":
+        logger.warning("workspace sync: cannot list %s (%s)",
+                       workspace_id, listed.get("stderr"))
+        return []
+
+    figures, tables = [], []
+    for line in sorted((listed.get("stdout") or "").splitlines()):
+        rel = line.strip().lstrip("./")
+        if not rel or _is_pruned(rel, repo_roots):
+            continue
+        if _looks_like(rel, _IMAGE_EXTS) and len(figures) < _MAX_WORKSPACE_FILES:
+            figures.append(rel)
+        elif _looks_like(rel, _TABLE_EXTS) and len(tables) < _MAX_WORKSPACE_FILES:
+            tables.append(rel)
+    return figures + tables
+
+
+async def _upload(toolset, workspace_id: str, rel_path: str,
+                  scope: tuple) -> Optional[Dict[str, Any]]:
+    """Mint a link, push the file from the sandbox, return the index entry."""
+    # The scope is passed explicitly. get_upload_link requires user_id and
+    # session_id, and SessionScopePlugin fills those only at the ADK tool
+    # boundary — this call does not go through one.
+    link = await call_vault(
+        "get_upload_link", user_id=scope[0], session_id=scope[1],
+        filename=_flatten(rel_path), feature="workspace",
+    )
+    if not link or not link.get("upload_url"):
+        return None
+
+    command = "python3 -c {} {} {}".format(
+        shlex.quote(_PUT_SNIPPET), shlex.quote(rel_path), shlex.quote(link["upload_url"])
+    )
+    res = await toolset._run_sync(command, workspace_id, max_wait=_UPLOAD_TIMEOUT)
+    if res.get("status") != "success":
+        logger.warning("workspace sync: upload of %s failed (%s)",
+                       rel_path, res.get("stderr"))
+        return None
+
+    # No ``url``. The upload link is a PUT capability and cannot fetch anything,
+    # and a download link minted now would expire before the report reads it.
+    # The collector mints a fresh one from the key through ``resolve_url``.
+    return {
+        "bucket": link.get("bucket"),
+        "s3_key": link.get("s3_key"),
+        "tool": "workspace",
+        "label": rel_path,
+    }
+
+
+async def sync_workspace_to_s3(tool_context: Any, state: Dict[str, Any]) -> Set[str]:
+    """Upload the remote sandbox artifacts and index them.
+
+    Returns the workspace-relative paths that reached S3. The collector skips
+    exactly those in its disk walk, so a file whose upload failed is still
+    collected from disk when the two share a host.
+    """
+    settings = get_settings()
+    if not settings.code_exec.url:
+        # Local mode. The files are already on this disk, and collect.py walks
+        # them. Uploading would put every figure in the report twice.
+        return set()
+    if not vault_url():
+        logger.info("workspace sync: MCP__VAULT_URL is not set, skipping")
+        return set()
+
+    workspace_id = _workspace_id(state)
+    if not workspace_id:
+        return set()
+
+    from CoScientist.tools.coder_tools.coder_tools import CoderToolset
+
+    toolset = CoderToolset()
+    files = await _list_files(toolset, workspace_id)
+    if not files:
+        return set()
+
+    # The same pair the vault builds its key from, sanitized the way
+    # SessionScopePlugin sanitizes it for every other vault call.
+    user_id, session_id = session_key(tool_context)
+    scope = (_safe_id(user_id, "unknown_user"), _safe_id(session_id, "unknown_session"))
+
+    entries, uploaded = [], set()
+    for rel in files:
+        entry = await _upload(toolset, workspace_id, rel, scope)
+        if entry:
+            entries.append(entry)
+            uploaded.add(rel)
+
+    artifact_index.record(entries, tool_context)
+    logger.info("workspace sync: uploaded %d of %d file(s) from %s",
+                len(uploaded), len(files), workspace_id)
+    return uploaded
+
+
+__all__ = ["sync_workspace_to_s3"]

--- a/mcp-servers/.env.example
+++ b/mcp-servers/.env.example
@@ -1,0 +1,35 @@
+# Copy this file to .env, in the same folder as docker-compose.yml.
+#
+# This file has two jobs:
+#   1. Docker Compose reads it for the ${...} values in docker-compose.yml.
+#   2. The chemical-mcp-server service loads it as its env_file. Every other
+#      server keeps its own .env in its own folder.
+# So this file must also carry the keys from chemical-mcp-server/.env.example.
+
+# Proxy for pip during an image build. The vault-mcp-server build passes it as
+# the HTTP_PROXY and HTTPS_PROXY build arguments. On a host with restricted
+# egress, an empty value makes the build fail.
+PIP_PROXY=
+
+# Lifetime of objects under ephemeral/. The minio-setup container of the
+# local-s3 profile writes the bucket lifecycle rule from this value.
+# The vault reads the same name from its own .env to set the link lifetime.
+# Set both to the same number, or a link outlives its object.
+EPHEMERAL_TTL_DAYS=7
+
+# --- chemical-mcp-server ---------------------------------------------------
+# Copied from chemical-mcp-server/.env.example. That service reads this file.
+CHEM_SERVICES_HOST=localhost
+CHEM_SERVICES_PORT=8005
+CHEM_SERVICES_TIMEOUT=60
+PROCESSED_IMG_STORAGE_PATH=/tmp/chemical_mcp_annotated
+RETROSYNTHESIS_SERVICES_HOST=localhost
+RETROSYNTHESIS_SERVICES_PORT=8001
+RETROSYNTHESIS_REQUEST_TIMEOUT=60
+CHEM_MCP_HOST=0.0.0.0
+CHEM_MCP_PORT=7331
+CHEM_MCP_PATH=/mcp
+S3__ENDPOINT_URL=
+S3__BUCKET_NAME=
+S3__ACCESS_KEY=
+S3__SECRET_KEY=

--- a/mcp-servers/vault-mcp-server/.env.example
+++ b/mcp-servers/vault-mcp-server/.env.example
@@ -1,14 +1,21 @@
 # Copy this file to .env and fill in the values.
 
-# Endpoint the server itself uses, from inside the container network.
+# Where the server itself reaches S3. The value below is the service name of
+# the MinIO that the local-s3 profile of docker-compose.yml starts.
 S3__ENDPOINT_URL=http://minio:9000
-# Endpoint the caller sees. The server signs presigned URLs for this host and
-# builds plain permanent/ URLs from it. A wrong value here gives links that
+# The endpoint the caller sees. The server signs presigned URLs for this host
+# and builds plain permanent/ URLs from it. A wrong value here gives links that
 # sign correctly but resolve nowhere.
+#
+# With an external S3 or MinIO, both values hold the SAME routable address.
+# The split above exists only for a MinIO in this Compose project, which has
+# one name inside the network and another one outside.
 S3__EXTERNAL_ENDPOINT_URL=http://localhost:9000
 
 S3__ACCESS_KEY=
 S3__SECRET_KEY=
+# Use a bucket of its own. The setup grants anonymous read on the permanent/
+# prefix, so a shared bucket exposes content the vault does not own.
 S3__BUCKET_NAME=agent-vault
 
 # Lifetime of objects under ephemeral/. The bucket lifecycle rule and the link
@@ -19,7 +26,9 @@ EPHEMERAL_TTL_DAYS=7
 # worker    — get_upload_link, get_download_link
 # framework — promote_artifact, cleanup_session, update_artifact_metadata,
 #             get_session_manifest, list_artifacts
-# Run two instances in production. Worker agents must not see the framework tools.
+# Keep this at all. CoScientist runs one instance: the worker toolset filters
+# the tool list on the client side, so an agent sees the worker pair only, and
+# framework code reaches promote_artifact on the same port.
 VAULT_SURFACE=all
 
 # Port inside the container. 7331 matches every sibling MCP server.

--- a/mcp-servers/vault-mcp-server/README.md
+++ b/mcp-servers/vault-mcp-server/README.md
@@ -32,7 +32,12 @@ The server builds every key. Callers never compose keys.
 ## Tool surfaces
 
 The env var `VAULT_SURFACE` selects the registered tools: `worker`, `framework`, or
-`all` (default). Run two instances in production.
+`all` (default).
+
+CoScientist runs one instance with `all`. The worker toolset names the two tools
+it wants, so an agent sees the worker surface only, and framework code reaches
+`promote_artifact` on the same port. Two instances also work, for a deployment
+that must keep the split on the server.
 
 - Worker surface: `get_upload_link`, `get_download_link`.
 - Framework surface: `promote_artifact`, `cleanup_session`, `update_artifact_metadata`,
@@ -43,16 +48,22 @@ Every tool returns JSON with `bucket`, `s3_key`, and a URL field. The pair
 
 ## Installation and setup
 
-1. Copy `.env.example` to `.env` and fill in the values.
+1. Copy `.env.example` to `.env` and fill in the values. Against an external S3
+   or MinIO, set `S3__ENDPOINT_URL` and `S3__EXTERNAL_ENDPOINT_URL` to the same
+   routable address.
 
-2. Start the server from `mcp-servers/`:
+2. Copy `mcp-servers/.env.example` to `mcp-servers/.env`. Docker Compose reads
+   that file for the build proxy. Without it, the image build runs `pip` with no
+   proxy, which fails on a host with restricted egress.
+
+3. Start the server from `mcp-servers/`:
    ```bash
    docker compose up -d --build vault-mcp-server
    ```
    It listens on host port 7338. Inside the network it listens on 7331, the same
    port as every sibling MCP server.
 
-3. To get a local MinIO with it, add the `local-s3` profile:
+4. To get a local MinIO with it, add the `local-s3` profile:
    ```bash
    docker compose --profile local-s3 up -d --build
    ```
@@ -64,7 +75,7 @@ Every tool returns JSON with `bucket`, `s3_key`, and a URL field. The pair
    compose file does not define, so a MinIO that starts by itself would change
    where they write.
 
-4. Against an external MinIO, run the last two setup commands once by hand:
+5. Against an external MinIO, run the last two setup commands once by hand:
    ```bash
    mc ilm rule add --expire-days 7 --prefix ephemeral/ <alias>/<bucket>
    mc anonymous set download <alias>/<bucket>/permanent
@@ -72,7 +83,7 @@ Every tool returns JSON with `bucket`, `s3_key`, and a URL field. The pair
    Skip them and nothing under `ephemeral/` expires, and the plain `permanent/`
    URLs do not resolve.
 
-5. Point an agent at the HTTP endpoint: `http://localhost:7338/mcp`
+6. Point an agent at the HTTP endpoint: `http://localhost:7338/mcp`
 
 ## Health and verification
 
@@ -101,13 +112,16 @@ Set `VAULT_MCP_URL` to reach a server on another host or port.
 
 ## Configuration
 
-- `S3__ENDPOINT_URL`: Internal Docker address for MinIO (`http://minio:9000`).
-- `S3__EXTERNAL_ENDPOINT_URL`: How the client sees MinIO (`http://localhost:9000`).
+- `S3__ENDPOINT_URL`: Where the server reaches S3. For a MinIO in this Compose
+  project, the service name (`http://minio:9000`).
+- `S3__EXTERNAL_ENDPOINT_URL`: How the caller sees S3 (`http://localhost:9000`).
+  Against an external S3 or MinIO, both keys hold the same routable address.
 - `S3__ACCESS_KEY`, `S3__SECRET_KEY`, `S3__BUCKET_NAME`: Credentials and bucket.
 - `EPHEMERAL_TTL_DAYS`: Lifetime of ephemeral objects. Default 7. The lifecycle
   rule in `docker-compose.yml` reads the same name from the compose `.env` file.
   Set it in both places, or a link outlives its object.
-- `VAULT_SURFACE`: `worker`, `framework`, or `all`. Default `all`.
+- `VAULT_SURFACE`: `worker`, `framework`, or `all`. Default `all`. See
+  "Tool surfaces" above.
 - `MCP_PORT`: Port inside the container. Default 8000. The compose file sets
   7331 to match the sibling servers.
 - `MINIO_*` names work as fallback aliases for one release.

--- a/mcp-servers/vault-mcp-server/vault_server.py
+++ b/mcp-servers/vault-mcp-server/vault_server.py
@@ -226,14 +226,26 @@ def cleanup_session(user_id: str, session_id: str, confirm: bool = False) -> str
             }, indent=2)
 
         deleted = 0
+        errors = []
         for i in range(0, len(keys), 1000):
             batch = keys[i:i + 1000]
-            s3_client.delete_objects(
+            # delete_objects reports a per-object refusal in Errors and still
+            # answers 200. Counting the batch would call a denied delete a
+            # success, and the caller would believe the session is gone.
+            resp = s3_client.delete_objects(
                 Bucket=BUCKET_NAME,
                 Delete={'Objects': [{'Key': k} for k in batch]},
             )
-            deleted += len(batch)
-        return json.dumps({"dry_run": False, "deleted": deleted}, indent=2)
+            deleted += len(resp.get('Deleted', []))
+            errors.extend(resp.get('Errors', []))
+
+        result = {"dry_run": False, "deleted": deleted, "requested": len(keys)}
+        if errors:
+            result["failed"] = len(errors)
+            result["errors"] = [
+                {"key": e.get('Key'), "code": e.get('Code')} for e in errors[:50]
+            ]
+        return json.dumps(result, indent=2)
     except (ValueError, ClientError) as e:
         return _err(str(e))
 

--- a/tests/unit/test_vault_integration.py
+++ b/tests/unit/test_vault_integration.py
@@ -1,0 +1,399 @@
+"""The vault consumption path: the client, promotion, and the workspace sync.
+
+Part 1 made every server produce a durable reference. These tests cover the
+other half — turning that reference back into a file, and moving the objects a
+report needs out of the prefix the lifecycle rule reclaims.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from CoScientist.config.report import ReportConfig
+from CoScientist.reporting import artifact_index, collect, finalize
+from CoScientist.tools import vault_client
+
+
+# --- the client ------------------------------------------------------------
+
+def _envelope(payload: dict):
+    """What an MCP call returns: a JSON string inside content[].text."""
+    return SimpleNamespace(content=[SimpleNamespace(text=json.dumps(payload))])
+
+
+def _fake_transport(monkeypatch, payload: dict):
+    """Replace the MCP transport, keeping the real envelope parsing."""
+    from contextlib import asynccontextmanager
+
+    import mcp
+    import mcp.client.streamable_http as streamable
+
+    class _Session:
+        def __init__(self, *a): pass
+        async def __aenter__(self): return self
+        async def __aexit__(self, *a): return False
+        async def initialize(self): return None
+        async def call_tool(self, name, args): return _envelope(payload)
+
+    @asynccontextmanager
+    async def _client(url, **kw):
+        yield (None, None, None)
+
+    monkeypatch.setattr(streamable, "streamablehttp_client", _client)
+    monkeypatch.setattr(mcp, "ClientSession", _Session)
+
+
+def test_the_reply_is_unwrapped_from_the_double_envelope():
+    """The vault returns a JSON string, and MCP wraps that string again."""
+    assert vault_client._payload(_envelope({"bucket": "b", "s3_key": "k"})) == {
+        "bucket": "b", "s3_key": "k"
+    }
+
+
+@pytest.mark.parametrize("result", [
+    SimpleNamespace(content=[]),
+    SimpleNamespace(content=[SimpleNamespace(text="not json")]),
+    SimpleNamespace(content=None),
+])
+def test_an_unreadable_reply_is_not_a_payload(result):
+    assert vault_client._payload(result) is None
+
+
+def test_a_vault_refusal_returns_none(monkeypatch):
+    """The vault reports a refusal in the body and answers 200. A caller that
+    read the body as a success would record a key that does not exist."""
+    monkeypatch.setattr(vault_client, "vault_url", lambda: "http://vault/mcp")
+    _fake_transport(monkeypatch, {"error": "only ephemeral objects can be promoted"})
+
+    assert asyncio.run(vault_client.call_vault("promote_artifact", s3_key="x")) is None
+
+
+def test_a_successful_call_returns_the_parsed_payload(monkeypatch):
+    monkeypatch.setattr(vault_client, "vault_url", lambda: "http://vault/mcp")
+    _fake_transport(monkeypatch, {"bucket": "agent-vault", "s3_key": "permanent/u/s/p.png"})
+
+    payload = asyncio.run(vault_client.call_vault("promote_artifact", s3_key="x"))
+    assert payload["s3_key"] == "permanent/u/s/p.png"
+
+
+def test_no_configured_url_is_not_an_error(monkeypatch):
+    """The vault is optional. A deployment without one still runs."""
+    monkeypatch.setattr(vault_client, "vault_url", lambda: None)
+    assert asyncio.run(vault_client.call_vault("get_download_link", s3_key="k")) is None
+
+
+def test_an_unreachable_vault_returns_none_instead_of_raising(monkeypatch):
+    monkeypatch.setattr(vault_client, "vault_url", lambda: "http://127.0.0.1:1/mcp")
+    assert asyncio.run(vault_client.call_vault("get_download_link", s3_key="k")) is None
+
+
+def test_the_sync_wrapper_refuses_to_run_on_the_event_loop():
+    """asyncio.run inside a live loop deadlocks it. Say so instead."""
+    async def main():
+        with pytest.raises(RuntimeError, match="event loop"):
+            vault_client.call_vault_sync("get_download_link", s3_key="k")
+
+    asyncio.run(main())
+
+
+# --- re-minting a dead link ------------------------------------------------
+
+@pytest.fixture()
+def index_root(tmp_path, monkeypatch):
+    monkeypatch.setenv("GRAPH_SNAPSHOT_DIR", str(tmp_path))
+    return tmp_path
+
+
+def _entry(url="http://expired/plot.png"):
+    return {"bucket": "agent-vault", "s3_key": "ephemeral/u1/s1/figures/plot.png",
+            "tool": "chem", "label": "plot.png", "url": url}
+
+
+def test_a_dead_url_is_reminted_from_the_durable_reference(index_root, tmp_path, monkeypatch):
+    """The cached presigned URL expired. The object did not."""
+    fresh = "http://minio/plot.png?sig=new"
+    downloaded = []
+
+    def fake_download(url, dest):
+        downloaded.append(url)
+        if url != fresh:
+            return False  # the expired link 403s
+        dest.write_bytes(b"x")
+        return True
+
+    monkeypatch.setattr(collect, "_download", fake_download)
+    artifact_index.record([_entry()], user_id="u1", session_id="s1")
+
+    result = collect.collect_artifacts(
+        session_id="s1", state={}, reports_root=tmp_path / "reports",
+        workspace_root=tmp_path / "ws", index_key=("u1", "s1"),
+        resolve_url=lambda uri: fresh,
+    )
+
+    assert downloaded == ["http://expired/plot.png", fresh]
+    assert len(result["figures"]) == 1
+
+
+def test_an_entry_with_no_url_at_all_is_resolved(index_root, tmp_path, monkeypatch):
+    """The workspace sync records a key and no URL: an upload link cannot fetch."""
+    seen = []
+    monkeypatch.setattr(collect, "_download",
+                        lambda url, dest: seen.append(url) or dest.write_bytes(b"x") or True)
+    entry = _entry(url=None)
+    entry.pop("url")
+    artifact_index.record([entry], user_id="u1", session_id="s1")
+
+    result = collect.collect_artifacts(
+        session_id="s1", state={}, reports_root=tmp_path / "reports",
+        workspace_root=tmp_path / "ws", index_key=("u1", "s1"),
+        resolve_url=lambda uri: f"http://minio/{uri.rsplit('/', 1)[-1]}",
+    )
+
+    assert seen == ["http://minio/plot.png"]
+    assert len(result["figures"]) == 1
+
+
+def test_a_resolver_that_raises_never_breaks_the_report(index_root, tmp_path, monkeypatch):
+    monkeypatch.setattr(collect, "_download", lambda url, dest: False)
+    artifact_index.record([_entry()], user_id="u1", session_id="s1")
+
+    def boom(uri):
+        raise RuntimeError("vault down")
+
+    result = collect.collect_artifacts(
+        session_id="s1", state={}, reports_root=tmp_path / "reports",
+        workspace_root=tmp_path / "ws", index_key=("u1", "s1"), resolve_url=boom,
+    )
+    assert result["figures"] == []
+
+
+# --- the mapping that crosses the stage boundary ---------------------------
+
+def test_collection_records_where_each_file_came_from(index_root, tmp_path, monkeypatch):
+    """collect_artifacts downloads to a local path and drops the key. finalize
+    runs later and needs it back, so the mapping goes on disk."""
+    monkeypatch.setattr(collect, "_download",
+                        lambda url, dest: dest.write_bytes(b"x") or True)
+    artifact_index.record([_entry(url="http://minio/plot.png")],
+                          user_id="u1", session_id="s1")
+
+    result = collect.collect_artifacts(
+        session_id="s1", state={}, reports_root=tmp_path / "reports",
+        workspace_root=tmp_path / "ws", index_key=("u1", "s1"),
+    )
+
+    sources = json.loads(
+        (Path(result["report_dir"]) / collect.SOURCES_FILENAME).read_text()
+    )
+    assert list(sources.values()) == [
+        {"bucket": "agent-vault", "s3_key": "ephemeral/u1/s1/figures/plot.png"}
+    ]
+    assert list(sources)[0].startswith("figures/")
+
+
+def test_a_url_only_artifact_produces_no_source_entry(index_root, tmp_path, monkeypatch):
+    """Some servers return no key. There is nothing to promote for those."""
+    monkeypatch.setattr(collect, "_download",
+                        lambda url, dest: dest.write_bytes(b"x") or True)
+    result = collect.collect_artifacts(
+        session_id="s1",
+        state={"mcp_artifacts": [{"url": "http://x/plot.png", "tool": "t"}]},
+        reports_root=tmp_path / "reports", workspace_root=tmp_path / "ws",
+    )
+    assert not (Path(result["report_dir"]) / collect.SOURCES_FILENAME).exists()
+
+
+# --- promotion at finalize -------------------------------------------------
+
+def _write_sources(report_dir: Path, mapping: dict) -> None:
+    report_dir.mkdir(parents=True, exist_ok=True)
+    (report_dir / collect.SOURCES_FILENAME).write_text(json.dumps(mapping))
+
+
+def test_finalize_promotes_each_collected_object(tmp_path, monkeypatch):
+    calls = []
+
+    def fake_call(tool, **args):
+        calls.append((tool, args))
+        return {"s3_key": "permanent/" + args["s3_key"][len("ephemeral/"):]}
+
+    monkeypatch.setattr(vault_client, "vault_url", lambda: "http://vault/mcp")
+    monkeypatch.setattr(vault_client, "call_vault_sync", fake_call)
+
+    cfg = ReportConfig(reports_root=str(tmp_path / "reports"), latex="skip")
+    _write_sources(
+        finalize.report_dir_for("s1", cfg.reports_root),
+        {"figures/plot.png": {"bucket": "b", "s3_key": "ephemeral/u1/s1/figures/plot.png"}},
+    )
+
+    result = finalize.finalize_report("s1", "# report", cfg)
+
+    assert calls == [("promote_artifact", {"s3_key": "ephemeral/u1/s1/figures/plot.png"})]
+    assert result.manifest["promoted"] == {
+        "figures/plot.png": "permanent/u1/s1/figures/plot.png"
+    }
+
+
+def test_a_file_that_was_never_in_s3_is_not_promoted(tmp_path, monkeypatch):
+    """A local sandbox leaves files on this disk only. A worker may not write
+    to permanent/ directly, so uploading them here is out of scope."""
+    monkeypatch.setattr(vault_client, "vault_url", lambda: "http://vault/mcp")
+    monkeypatch.setattr(vault_client, "call_vault_sync",
+                        lambda *a, **k: pytest.fail("must not call the vault"))
+
+    cfg = ReportConfig(reports_root=str(tmp_path / "reports"), latex="skip")
+    _write_sources(finalize.report_dir_for("s1", cfg.reports_root),
+                   {"figures/local.png": {"bucket": "b", "s3_key": "permanent/x/y.png"}})
+
+    assert finalize.finalize_report("s1", "# r", cfg).manifest["promoted"] == {}
+
+
+def test_a_vault_that_is_down_still_leaves_a_full_manifest(tmp_path, monkeypatch):
+    """Losing durability must not lose the deliverable."""
+    monkeypatch.setattr(vault_client, "vault_url", lambda: "http://vault/mcp")
+    monkeypatch.setattr(vault_client, "call_vault_sync", lambda *a, **k: None)
+
+    cfg = ReportConfig(reports_root=str(tmp_path / "reports"), latex="skip")
+    _write_sources(finalize.report_dir_for("s1", cfg.reports_root),
+                   {"figures/p.png": {"bucket": "b", "s3_key": "ephemeral/u/s/p.png"}})
+
+    result = finalize.finalize_report("s1", "# report", cfg)
+    assert result.report_dir is not None
+    assert result.manifest["report"] == "report.md"
+    assert result.manifest["promoted"] == {}
+
+
+def test_finalize_without_a_vault_url_writes_the_usual_manifest(tmp_path, monkeypatch):
+    monkeypatch.setattr(vault_client, "vault_url", lambda: None)
+    cfg = ReportConfig(reports_root=str(tmp_path / "reports"), latex="skip")
+    _write_sources(finalize.report_dir_for("s1", cfg.reports_root),
+                   {"figures/p.png": {"bucket": "b", "s3_key": "ephemeral/u/s/p.png"}})
+
+    manifest = finalize.finalize_report("s1", "# report", cfg).manifest
+    assert manifest["promoted"] == {}
+    assert manifest["session_id"] == "s1"
+
+
+def test_a_synced_file_is_not_collected_from_disk_as_well(tmp_path, monkeypatch):
+    """The code-exec server may run on this host, and both sides use
+    code_exec.workspace_root. Walking the same file again would put the figure
+    in the report twice, once from S3 and once from disk."""
+    monkeypatch.setattr(collect, "_download",
+                        lambda url, dest: dest.write_bytes(b"x") or True)
+    ws = tmp_path / "ws" / "ws_s1"
+    ws.mkdir(parents=True)
+    (ws / "loss.png").write_bytes(b"x")
+
+    result = collect.collect_artifacts(
+        session_id="s1",
+        state={"mcp_artifacts": [{"url": "http://minio/ws_loss.png", "tool": "workspace"}]},
+        reports_root=tmp_path / "reports", workspace_root=tmp_path / "ws",
+        synced_files={"loss.png"},
+    )
+    assert len(result["figures"]) == 1
+    assert result["blocks_markdown"].count("### ") == 1
+
+
+def test_a_file_the_sync_failed_to_upload_is_still_collected(tmp_path):
+    """Naming the synced files, rather than switching the walk off, keeps a
+    failed upload reachable from disk."""
+    ws = tmp_path / "ws" / "ws_s1"
+    ws.mkdir(parents=True)
+    (ws / "sent.png").write_bytes(b"x")
+    (ws / "failed.png").write_bytes(b"x")
+
+    result = collect.collect_artifacts(
+        session_id="s1", state={}, reports_root=tmp_path / "reports",
+        workspace_root=tmp_path / "ws", synced_files={"sent.png"},
+    )
+    assert [Path(f).name for f in result["figures"]] == ["failed.png"]
+
+
+def test_the_disk_walk_still_runs_by_default(tmp_path):
+    """Local mode uploads nothing, so the walk is the only source."""
+    ws = tmp_path / "ws" / "ws_s1"
+    ws.mkdir(parents=True)
+    (ws / "loss.png").write_bytes(b"x")
+
+    result = collect.collect_artifacts(
+        session_id="s1", state={}, reports_root=tmp_path / "reports",
+        workspace_root=tmp_path / "ws",
+    )
+    assert len(result["figures"]) == 1
+
+
+# --- what an upload link must not become -----------------------------------
+
+def _capture(tool_name, result, tool_context):
+    from CoScientist.tools.mcp_artifact_plugin import McpArtifactCapturePlugin
+    plugin = McpArtifactCapturePlugin()
+    asyncio.run(plugin.after_tool_callback(
+        tool=SimpleNamespace(name=tool_name), tool_args={},
+        tool_context=tool_context, result=result,
+    ))
+
+
+def test_an_upload_link_is_indexed_without_its_url(index_root, monkeypatch):
+    """A PUT-signed URL cannot fetch the object, and the object may not exist
+    yet — the agent was only handed somewhere to put one."""
+    recorded = []
+    monkeypatch.setattr("CoScientist.tools.mcp_artifact_plugin.record",
+                        lambda entries, ctx=None, **kw: recorded.extend(entries))
+    _capture("get_upload_link",
+             {"bucket": "agent-vault", "s3_key": "ephemeral/u/s/workspace/plot.png",
+              "upload_url": "http://minio/plot.png?X-Amz-Signature=put"},
+             SimpleNamespace(state={}))
+
+    assert len(recorded) == 1
+    assert recorded[0]["url"] is None
+    assert recorded[0]["s3_key"] == "ephemeral/u/s/workspace/plot.png"
+
+
+def test_a_worker_file_that_is_not_a_figure_or_table_is_not_indexed(index_root, monkeypatch):
+    """An agent parks whatever it likes in the vault. An unknown extension is
+    collected as a table, so a checkpoint would be rendered as one."""
+    recorded = []
+    monkeypatch.setattr("CoScientist.tools.mcp_artifact_plugin.record",
+                        lambda entries, ctx=None, **kw: recorded.extend(entries))
+    _capture("get_upload_link",
+             {"bucket": "agent-vault", "s3_key": "ephemeral/u/s/workspace/model.pkl",
+              "upload_url": "http://minio/model.pkl?X-Amz-Signature=put"},
+             SimpleNamespace(state={}))
+
+    assert recorded == []
+
+
+def test_a_normal_tool_result_still_keeps_its_url(index_root, monkeypatch):
+    """Only get_upload_link is special. Every other server returns a URL that
+    downloads, and the report uses it inside the same run."""
+    recorded = []
+    monkeypatch.setattr("CoScientist.tools.mcp_artifact_plugin.record",
+                        lambda entries, ctx=None, **kw: recorded.extend(entries))
+    _capture("visualize_molecule",
+             {"bucket": "b", "s3_key": "ephemeral/u/s/chem/mol.png",
+              "presigned_url": "http://minio/mol.png?sig=1"},
+             SimpleNamespace(state={}))
+
+    assert recorded[0]["url"] == "http://minio/mol.png?sig=1"
+
+
+# --- a malformed side file must not cost the deliverable -------------------
+
+@pytest.mark.parametrize("content", ['["not", "a", "mapping"]', '"a string"',
+                                     '{"figures/p.png": "not a dict"}'])
+def test_a_malformed_source_file_leaves_the_report_intact(tmp_path, monkeypatch, content):
+    """An escape from promotion lands in finalize_report's except, which reports
+    the whole deliverable as missing while report.md sits complete on disk."""
+    monkeypatch.setattr(vault_client, "vault_url", lambda: "http://vault/mcp")
+    cfg = ReportConfig(reports_root=str(tmp_path / "reports"), latex="skip")
+    report_dir = finalize.report_dir_for("s1", cfg.reports_root)
+    report_dir.mkdir(parents=True, exist_ok=True)
+    (report_dir / collect.SOURCES_FILENAME).write_text(content)
+
+    result = finalize.finalize_report("s1", "# report", cfg)
+    assert result.report_dir is not None
+    assert result.manifest["promoted"] == {}

--- a/tests/unit/test_workspace_sync.py
+++ b/tests/unit/test_workspace_sync.py
@@ -1,0 +1,233 @@
+"""Pushing a remote sandbox workspace into S3.
+
+With CODE_EXEC__URL set, the run's figures sit on the code-exec host and the
+local disk walk in collect.py finds nothing. The code-exec API cannot serve a
+file, so the sandbox uploads with a presigned link the vault mints.
+"""
+from __future__ import annotations
+
+import asyncio
+import re
+from types import SimpleNamespace
+
+import pytest
+
+from CoScientist.tools import workspace_sync
+
+
+class _FakeToolset:
+    """Stands in for CoderToolset. Records every command it was asked to run."""
+
+    def __init__(self, listing: str, repos: str = "", fail: bool = False):
+        self.listing, self.repos, self.fail = listing, repos, fail
+        self.commands = []
+
+    async def _run_sync(self, command, workspace_id, max_wait=30):
+        self.commands.append(command)
+        if "-name .git" in command:
+            return {"status": "success", "stdout": self.repos}
+        if command.startswith("find "):
+            return {"status": "success", "stdout": self.listing}
+        if self.fail:
+            return {"status": "error", "stderr": "no such file"}
+        return {"status": "success", "stdout": ""}
+
+
+@pytest.fixture()
+def wired(monkeypatch, tmp_path):
+    """A remote code-exec host, a configured vault, and an index in tmp_path."""
+    monkeypatch.setenv("GRAPH_SNAPSHOT_DIR", str(tmp_path))
+    monkeypatch.setattr(workspace_sync, "vault_url", lambda: "http://vault/mcp")
+
+    settings = workspace_sync.get_settings()
+    monkeypatch.setattr(settings.code_exec, "url", "http://code-exec:8131")
+    monkeypatch.setattr(settings.web, "coder_workspace_id", None)
+
+    recorded = []
+    monkeypatch.setattr(workspace_sync.artifact_index, "record",
+                        lambda entries, ctx=None, **kw: recorded.extend(entries))
+    return recorded
+
+
+_FILENAME_RE = re.compile(r"^[a-zA-Z0-9_.-]{1,128}$")  # vault_server._FILENAME_RE
+_ID_RE = re.compile(r"^[a-zA-Z0-9_-]{1,64}$")          # vault_server._ID_RE
+
+
+def _links(monkeypatch, calls):
+    """A vault stand-in that validates its arguments the way the real one does.
+
+    get_upload_link takes user_id and session_id and has no defaults for them,
+    and it rejects a filename outside its charset. A fake that swallows any
+    kwargs would hide a call the real server refuses.
+    """
+    async def fake(tool, **args):
+        for name in ("user_id", "session_id"):
+            assert name in args, f"the vault requires {name}"
+            assert _ID_RE.match(args[name]), f"bad {name}: {args[name]!r}"
+        assert _FILENAME_RE.match(args["filename"]), f"bad filename: {args['filename']!r}"
+        calls.append(args)
+        return {"bucket": "agent-vault",
+                "s3_key": f"ephemeral/u1/s1/workspace/{args['filename']}",
+                "upload_url": f"http://minio/{args['filename']}?sig=1"}
+
+    monkeypatch.setattr(workspace_sync, "call_vault", fake)
+
+
+def _run(toolset, monkeypatch, state=None):
+    monkeypatch.setattr(
+        "CoScientist.tools.coder_tools.coder_tools.CoderToolset",
+        lambda *a, **k: toolset,
+    )
+    return asyncio.run(workspace_sync.sync_workspace_to_s3(
+        SimpleNamespace(state={}), state if state is not None else {"coder_workspace_id": "ws_abc"}
+    ))
+
+
+def test_every_figure_and_table_is_uploaded_and_indexed(wired, monkeypatch):
+    calls = []
+    _links(monkeypatch, calls)
+    toolset = _FakeToolset("./plots/loss.png\n./results.csv\n./notes.txt\n")
+
+    assert _run(toolset, monkeypatch) == {"plots/loss.png", "results.csv"}
+    assert [c["filename"] for c in calls] == ["plots_loss.png", "results.csv"]
+    assert all(c["feature"] == "workspace" for c in calls)
+    # notes.txt is neither a figure nor a table.
+    assert len(wired) == 2
+    assert wired[0]["s3_key"] == "ephemeral/u1/s1/workspace/plots_loss.png"
+
+
+def test_an_index_entry_carries_no_url(wired, monkeypatch):
+    """An upload link is a PUT capability. It cannot fetch the object back, and
+    a download link minted now would expire before the report reads it."""
+    _links(monkeypatch, [])
+    _run(_FakeToolset("./plot.png\n"), monkeypatch)
+    assert "url" not in wired[0]
+    assert wired[0]["bucket"] and wired[0]["s3_key"]
+
+
+def test_two_files_with_one_basename_get_two_keys(wired, monkeypatch):
+    """A flat key would let the second upload overwrite the first."""
+    calls = []
+    _links(monkeypatch, calls)
+    _run(_FakeToolset("./plots/loss.png\n./runs/2/loss.png\n"), monkeypatch)
+    assert [c["filename"] for c in calls] == ["plots_loss.png", "runs_2_loss.png"]
+
+
+def test_a_cloned_repo_subtree_is_skipped(wired, monkeypatch):
+    """A coder step may clone a whole library. Its bundled example images are
+    not run outputs, and collecting them buries the real figures."""
+    calls = []
+    _links(monkeypatch, calls)
+    toolset = _FakeToolset(
+        "./rdkit_repo/docs/logo.png\n./node_modules/x/icon.png\n./plot.png\n",
+        repos="./rdkit_repo/.git\n",
+    )
+    _run(toolset, monkeypatch)
+    assert [c["filename"] for c in calls] == ["plot.png"]
+
+
+def test_the_upload_needs_no_curl(wired, monkeypatch):
+    """The code-exec image is python:3.12-slim plus build-essential, vim and
+    git. It has no curl, and it always has python3."""
+    _links(monkeypatch, [])
+    toolset = _FakeToolset("./plot.png\n")
+    _run(toolset, monkeypatch)
+    upload = [c for c in toolset.commands if not c.startswith("find ")]
+    assert len(upload) == 1
+    assert upload[0].startswith("python3 -c ")
+    assert "curl" not in upload[0]
+
+
+def test_a_failed_upload_is_left_out_of_the_index(wired, monkeypatch):
+    _links(monkeypatch, [])
+    assert _run(_FakeToolset("./plot.png\n", fail=True), monkeypatch) == set()
+    assert wired == []
+
+
+def test_local_mode_syncs_nothing(wired, monkeypatch):
+    """The files are already on this disk and collect.py walks them. Uploading
+    would put every figure in the report twice."""
+    monkeypatch.setattr(workspace_sync.get_settings().code_exec, "url", None)
+    monkeypatch.setattr(workspace_sync, "call_vault",
+                        lambda *a, **k: pytest.fail("must not reach the vault"))
+    assert _run(_FakeToolset("./plot.png\n"), monkeypatch) == set()
+
+
+def test_no_configured_vault_syncs_nothing(wired, monkeypatch):
+    monkeypatch.setattr(workspace_sync, "vault_url", lambda: None)
+    assert _run(_FakeToolset("./plot.png\n"), monkeypatch) == set()
+
+
+def test_a_session_with_no_coder_step_syncs_nothing(wired, monkeypatch):
+    """The workspace id is pinned in session state, not derived from the session
+    id. No id means no sandbox was ever created."""
+    monkeypatch.setattr(workspace_sync, "call_vault",
+                        lambda *a, **k: pytest.fail("must not reach the vault"))
+    assert _run(_FakeToolset("./plot.png\n"), monkeypatch, state={}) == set()
+
+
+def test_an_env_pinned_workspace_is_still_found(wired, monkeypatch):
+    """The A2A shared workspace is pinned through CODER_WORKSPACE_ID, and the
+    coder toolset never writes that id to state. Reading state alone misses it."""
+    calls = []
+    _links(monkeypatch, calls)
+    monkeypatch.setenv("CODER_WORKSPACE_ID", "shared-run")
+
+    assert _run(_FakeToolset("./plot.png\n"), monkeypatch, state={}) == {"plot.png"}
+    assert calls[0]["filename"] == "plot.png"
+
+
+def test_the_pin_wins_over_the_state_id(wired, monkeypatch):
+    _links(monkeypatch, [])
+    monkeypatch.setenv("CODER_WORKSPACE_ID", "shared-run")
+    toolset = _FakeToolset("./plot.png\n")
+    _run(toolset, monkeypatch, state={"coder_workspace_id": "ws_other"})
+    assert workspace_sync._workspace_id({"coder_workspace_id": "ws_other"}) == "ws_shared-run"
+
+
+def test_the_scope_the_vault_needs_is_passed_explicitly(wired, monkeypatch):
+    """get_upload_link requires user_id and session_id. SessionScopePlugin fills
+    those at the ADK tool boundary, and this call does not go through one."""
+    calls = []
+    _links(monkeypatch, calls)
+    ctx = SimpleNamespace(_invocation_context=SimpleNamespace(
+        session=SimpleNamespace(id="sess-1", user_id="alice@example.com", state={})))
+    monkeypatch.setattr(
+        "CoScientist.tools.coder_tools.coder_tools.CoderToolset",
+        lambda *a, **k: _FakeToolset("./plot.png\n"))
+
+    asyncio.run(workspace_sync.sync_workspace_to_s3(ctx, {"coder_workspace_id": "ws_a"}))
+    # Sanitized to the vault id charset, the same way every other call is.
+    assert calls[0]["user_id"] == "alice_example_com"
+    assert calls[0]["session_id"] == "sess-1"
+
+
+@pytest.mark.parametrize("name,expected", [
+    ("roc curve (fold 1).png", "roc_curve_fold_1_.png"),
+    ("ünïcode.png", "n_code.png"),
+    ("a/b/c.csv", "a_b_c.csv"),
+])
+def test_a_filename_is_made_to_fit_the_vault_charset(name, expected):
+    """The vault rejects anything outside ^[a-zA-Z0-9_.-]{1,128}$, and a sandbox
+    writes names it rejects."""
+    assert workspace_sync._flatten(name) == expected
+
+
+def test_a_long_filename_is_truncated_but_keeps_its_extension():
+    """The report tells a figure from a table by the extension."""
+    flat = workspace_sync._flatten("x" * 300 + ".png")
+    assert len(flat) <= 128 and flat.endswith(".png")
+
+
+def test_a_failed_repository_probe_syncs_nothing(wired, monkeypatch):
+    """Without that list nothing prunes a cloned library, and its bundled
+    example images would fill the report."""
+    _links(monkeypatch, [])
+
+    class _Broken(_FakeToolset):
+        async def _run_sync(self, command, workspace_id, max_wait=30):
+            if "-name .git" in command:
+                return {"status": "timeout", "stderr": "took too long"}
+            return await super()._run_sync(command, workspace_id, max_wait)
+
+    assert _run(_Broken("./plot.png\n"), monkeypatch) == set()


### PR DESCRIPTION
# S3 vault integration, part 2: consume the durable reference

Follows #<part 1>. Branch from `feature/s3-vault-integration`, so review that one
first. If part 1 merges before this, the branch fast-forwards.

Part 1 made every MCP server produce `bucket` + `s3_key` + `presigned_url`, put
every object under `ephemeral/<user_id>/<session_id>/`, and kept the durable
reference in graph nodes and in a per-session artifact index. Nothing read one
back. CoScientist had no vault client, so an `s3://bucket/key` could not become
a file again. `collect_artifacts` counted these entries and logged the gap.

This branch adds the client and handoff changes 6, 8 and 9.

## What changed

**The vault client.** `CoScientist/tools/vault_client.py` opens one MCP session
per call and closes it. The ADK session manager caches a session and binds its
exit stack to the loop that created it, so a shared instance fails on the second
call from a fresh loop. `call_vault_sync` refuses to run on the event loop, where
`asyncio.run` would deadlock.

**Two consumers, two mechanisms.** Worker agents get a normal ADK `McpToolset`,
filtered to `get_upload_link` and `get_download_link`. The vault also exposes
`promote_artifact`, `cleanup_session`, `update_artifact_metadata`,
`get_session_manifest` and `list_artifacts`. An agent never sees those. Framework
code calls them through the client, outside any agent.

**Change 6, the remote workspace.** `collect.py` walks `workspace/ws_<session>`
on the local disk. With `CODE_EXEC__URL` set the files sit on the code-exec host,
the walk finds nothing, and the report loses every figure the run drew.

The code-exec API is submit and result only. It cannot serve a file. So the file
leaves from the inside: the framework mints a presigned PUT link with the vault,
and the sandbox uploads to S3 with it. Part 1's content-type fix is what makes
that bare PUT work.

The upload runs through `python3` and `urllib`, not `curl`. The code-exec image
(`docker/Dockerfile`) is `python:3.12-slim` plus build-essential, vim and git. It
has no curl, and it always has python3.

**Change 8, promotion.** A worker writes under `ephemeral/`, where the lifecycle
rule deletes the object after `EPHEMERAL_TTL_DAYS` (default 7). The report
outlives that. `collect_artifacts` downloads to a local path and drops the key,
so it now writes the mapping to `.artifact_sources.json` in the report folder.
`finalize_report` reads that file, promotes each object, and writes the new
`permanent/` keys into `MANIFEST.json` under a new `promoted` map.

**Change 9, the tool split.** One vault instance, filtered client-side with the
ADK `tool_filter`. A second `VAULT_SURFACE` instance is not needed: the presigned
URL points at S3, not at the vault, so the sandbox needs egress to S3 only and
the vault stays private to CoScientist. `docker-compose.yml` is unchanged.

## Two departures from the handoff

**Change 6 does not go in `finalize.py`.** The handoff points there and says "at
run end". The bug it names is lost figures, and a figure reaches the report only
through `collect_artifacts`, which runs earlier, when the aggregator calls
`format_results`. A sync at finalize time would be strictly too late. It runs in
`format_results`, before collection.

**Promotion covers only what S3 already holds.** `report.md`, the LaTeX output
and the files a local sandbox left on this disk were never uploaded. Handoff item
8.1 forbids a worker writing to `permanent/` directly, so promoting those would
mean upload-then-promote. The handoff asks for the figures the report references,
and that is the scope here.

## Also in scope

- `collect_artifacts` takes a `resolve_url` callable. A presigned URL lives one
  hour, so a long run — or one that was restarted — arrives holding dead links.
  The object is still there, and the vault mints a new URL from the key beside
  it. The function stays synchronous and reaches no network itself, which keeps
  it testable and keeps the existing tests valid.
- The artifact loop now dedupes on the durable reference, not only on the URL.
  Two entries for one object can carry two different presigned URLs.
- `collect_artifacts` takes `synced_files`. What the sync uploaded arrives
  through the index, and the disk walk would find the same files again. The two
  paths overlap whenever the code-exec server runs on this host, which is the
  documented dev setup: both sides read `code_exec.workspace_root`. Naming the
  files rather than switching the walk off keeps a failed upload reachable.
- `McpArtifactCapturePlugin` no longer stores an `upload_url` as an artifact URL,
  and it indexes an uploaded worker file only when the name looks like a figure
  or a table. Now that agents hold the vault, a `get_upload_link` reply would
  otherwise be indexed before anything was uploaded, and a checkpoint an agent
  parked there would be downloaded into `tables/` and rendered as one.
- Collection now runs in `asyncio.to_thread`. It downloads every artifact, and
  each dead link adds a vault round trip, all of which used to block the event
  loop.
- `cleanup_session` added `len(batch)` to its deleted count and never read the
  `Errors` key that `delete_objects` returns. A partly denied delete reported
  full success. It now counts `Deleted` and reports the failures.

## One thing worth a second look

`finalize_report` now reaches the network. It is wrapped, and a vault that is
down costs the deliverable its durability and not its existence — there is a
test for that. But it is a new runtime dependency in a path that had none.

The mapping travels through a file rather than session state on purpose:
`web/app.py:1893` passes `state=None` to `finalize_report` while `main.py:389`
passes the real state. Anything hung off state there would silently do nothing in
the web path. That is the same shape as the plugin-list gap the part-1 review
found.

## Verification

`.venv/bin/python -m pytest tests/unit -q` gives 528 passed and 3 failed. The
three (`test_hitl_agenttool_scope` twice, `test_opik_tracer` once, the last needs
an Opik API key) fail on `main` as well. 44 new tests cover the client envelope
and its failure modes, re-minting, the source mapping, promotion with the vault
up and down, and the workspace sync.

These need a live stack and did not run:

1. Call `get_upload_link` and `get_download_link` from a CoderAgent turn. Confirm
   the agent cannot see `cleanup_session` or `promote_artifact`.
2. Run one pipeline with `CODE_EXEC__URL` set. The report carries the sandbox
   figures, and they sit under `ephemeral/<user>/<session>/workspace/` in MinIO.
3. Run the same pipeline with `CODE_EXEC__URL` empty. The figures still arrive
   through the disk walk, and no figure appears twice.
4. Run it once more with the code-exec server on this host. The sandbox and the
   report collector then share a directory, and each figure must still appear
   once.
5. After the run, `MANIFEST.json` carries a `promoted` entry per figure, and each
   key resolves under `permanent/`.
6. Grep `execution.json` for `presigned_url` and `X-Amz-Signature`. Expect no
   match.
7. Stop the vault container and run a pipeline. The report still completes.

## Configuration

One new setting: `MCP__VAULT_URL`, for example
`http://localhost:7338/mcp` against the compose stack. Unset, the toolset and
every framework call drop out and the run behaves as it does today.

## Not in this branch

CI for `mcp-servers/`. `.github/workflows/` holds only `deploy-web.yml`, so no
server there deploys on a merge to main. It is deploy plumbing with no overlap
with this code.