### PR TITLE
fedot logger + ui

### DIFF
--- a/CoScientist/logging/fedot_bridge.py
+++ b/CoScientist/logging/fedot_bridge.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import logging
+import os
+
+from loguru import logger as _loguru_logger
+
+_FULL_LEVEL = "TRACE"
+
+logging.addLevelName(5, "TRACE")
+_log = logging.getLogger("CoScientist.fedotmas")
+_log.setLevel(1)
+if not any(isinstance(h, logging.StreamHandler) for h in _log.handlers):
+    _handler = logging.StreamHandler()
+    _handler.setFormatter(
+        logging.Formatter("%(asctime)s - %(levelname)s - %(name)s - %(message)s")
+    )
+    _log.addHandler(_handler)
+
+_patched = False
+
+
+def _sink(message) -> None:
+    record = message.record
+    name = record["extra"].get("name", "fedotmas")
+    _log.log(
+        record["level"].no,
+        "%s:%s:%s | %s",
+        name,
+        record["function"],
+        record["line"],
+        record["message"],
+    )
+
+
+def _install_bridge(level: str | None = None) -> None:
+    resolved = (level or os.getenv("FEDOTMAS_LOG_LEVEL") or _FULL_LEVEL).upper()
+    _loguru_logger.remove()
+    _loguru_logger.add(_sink, level=resolved)
+
+
+def patch_fedotmas_logging() -> None:
+    global _patched
+    if _patched:
+        return
+    from fedotmas.core import base as _fedotmas_base
+
+    _fedotmas_base.setup_logging = _install_bridge
+    _install_bridge()
+    _patched = True

--- a/CoScientist/tools/fedot_trace_handler.py
+++ b/CoScientist/tools/fedot_trace_handler.py
@@ -1,0 +1,85 @@
+import logging
+import time
+from typing import Optional
+
+logger = logging.getLogger("CoScientist.web.fedot_trace")
+
+# Keep enough history that a tab opened mid-run still sees what already
+# happened, without holding an unbounded log for a long-lived server.
+_EVENT_LOG_LIMIT = 500
+
+
+class FedotTraceHandler:
+    """Broadcasts FEDOT.MAS trace events to every connected /fedot-trace tab."""
+
+    def __init__(self):
+        self._sockets: list = []
+        self._event_log: list[dict] = []
+        self._active = False
+
+    @property
+    def is_active(self) -> bool:
+        return self._active
+
+    async def attach_websocket(self, ws) -> None:
+        """Register a (re)connected browser socket and replay recent history,
+        so a tab opened mid-run isn't staring at a blank page."""
+        if ws not in self._sockets:
+            self._sockets.append(ws)
+        logger.info("FEDOT trace websocket attached (%d connection(s))", len(self._sockets))
+        for payload in self._event_log:
+            try:
+                await ws.send_json(payload)
+            except Exception as exc:  # noqa: BLE001 — replay is best-effort
+                logger.warning("FEDOT trace replay to a new connection failed: %s", exc)
+                break
+
+    def detach_websocket(self, ws) -> None:
+        try:
+            self._sockets.remove(ws)
+        except ValueError:
+            pass
+        logger.info("FEDOT trace websocket detached (%d connection(s) left)", len(self._sockets))
+
+    async def mark_run_start(self, run_id: str, task_description: str) -> None:
+        self._active = True
+        await self.broadcast({
+            "type": "fedot_trace_event",
+            "event": "run_start",
+            "run_id": run_id,
+            "task_description": task_description,
+        })
+
+    async def mark_run_end(self, run_id: str, status: str, error: Optional[str] = None) -> None:
+        self._active = False
+        payload = {
+            "type": "fedot_trace_event",
+            "event": "run_end",
+            "run_id": run_id,
+            "status": status,
+        }
+        if error:
+            payload["error"] = error
+        await self.broadcast(payload)
+
+    async def broadcast(self, payload: dict) -> int:
+        """Log + send to every connected tab, pruning dead sockets."""
+        payload.setdefault("timestamp", time.time())
+        self._event_log.append(payload)
+        if len(self._event_log) > _EVENT_LOG_LIMIT:
+            del self._event_log[: len(self._event_log) - _EVENT_LOG_LIMIT]
+
+        delivered = 0
+        for ws in list(self._sockets):
+            try:
+                await ws.send_json(payload)
+                delivered += 1
+            except Exception as exc:  # noqa: BLE001 — prune and continue
+                logger.warning("FEDOT trace delivery to a socket failed (%s) — pruning", exc)
+                self.detach_websocket(ws)
+        return delivered
+
+
+# Module-level singleton — one FEDOT.MAS trace stream per server process,
+# same lifetime convention as _web_hitl_handler in CoScientist/web/app.py.
+fedot_trace_handler = FedotTraceHandler()

--- a/CoScientist/tools/fedot_trace_plugin.py
+++ b/CoScientist/tools/fedot_trace_plugin.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from google.adk.events import Event
+from google.adk.plugins import BasePlugin
+from google.adk.runners import InvocationContext
+
+from CoScientist.tools.fedot_trace_handler import FedotTraceHandler
+
+_MAX_FIELD_CHARS = 800
+
+
+def _unwrap_json_strings(obj: Any) -> Any:
+    if isinstance(obj, dict):
+        return {k: _unwrap_json_strings(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [_unwrap_json_strings(v) for v in obj]
+    if isinstance(obj, str) and obj[:1] in "{[":
+        try:
+            return _unwrap_json_strings(json.loads(obj))
+        except (TypeError, ValueError):
+            return obj
+    return obj
+
+
+def _safe_text(value: Any) -> str:
+    try:
+        text = json.dumps(_unwrap_json_strings(value), default=str, ensure_ascii=False)
+    except (TypeError, ValueError):
+        text = str(value)
+    if len(text) > _MAX_FIELD_CHARS:
+        text = text[:_MAX_FIELD_CHARS] + f"… ({len(text)} chars total)"
+    return text
+
+
+def _request_shape(llm_request: Any) -> dict[str, Any]:
+    """Cheap, no-tokenizer summary of an LlmRequest's size — attached to
+    ``model_error`` so a context-window overflow shows its own cause (a huge
+    ``max_output_tokens``, or a history that grew too long) right in the
+    trace, instead of only the provider's raw error text.
+    """
+    try:
+        config = getattr(llm_request, "config", None)
+        contents = getattr(llm_request, "contents", None) or []
+        chars = 0
+        for content in contents:
+            for part in getattr(content, "parts", None) or []:
+                chars += len(getattr(part, "text", None) or "")
+        return {
+            "model": getattr(llm_request, "model", None),
+            "max_output_tokens": getattr(config, "max_output_tokens", None),
+            "turns": len(contents),
+            "prompt_chars": chars,
+        }
+    except Exception:  # noqa: BLE001 — this is diagnostic best-effort, never fatal
+        return {}
+
+
+class FedotTracePlugin(BasePlugin):
+    """Forwards FEDOT.MAS's ADK-level agent/tool events to a FedotTraceHandler."""
+
+    def __init__(self, handler: FedotTraceHandler, run_id: str, name: str = "fedot_trace") -> None:
+        super().__init__(name)
+        self._handler = handler
+        self._run_id = run_id
+
+    async def _emit(self, event: str, **fields: Any) -> None:
+        payload = {"type": "fedot_trace_event", "event": event, "run_id": self._run_id, **fields}
+        try:
+            await self._handler.broadcast(payload)
+        except Exception:  # noqa: BLE001 — tracing must never break the actual run
+            pass
+
+    async def before_agent_callback(self, *, agent, callback_context):  # noqa: ANN001
+        await self._emit("agent_start", agent_name=getattr(agent, "name", None))
+        return None
+
+    async def after_agent_callback(self, *, agent, callback_context):  # noqa: ANN001
+        await self._emit("agent_end", agent_name=getattr(agent, "name", None))
+        return None
+
+    async def before_tool_callback(self, *, tool, tool_args, tool_context):  # noqa: ANN001
+        await self._emit(
+            "tool_start",
+            tool_name=getattr(tool, "name", None),
+            tool_args=_safe_text(tool_args),
+        )
+        return None
+
+    async def after_tool_callback(self, *, tool, tool_args, tool_context, result):  # noqa: ANN001
+        await self._emit(
+            "tool_end",
+            tool_name=getattr(tool, "name", None),
+            result_summary=_safe_text(result),
+        )
+        return None
+
+    async def on_tool_error_callback(self, *, tool, tool_args, tool_context, error):  # noqa: ANN001
+        await self._emit(
+            "tool_error",
+            tool_name=getattr(tool, "name", None),
+            error=str(error),
+        )
+        return None
+
+    async def on_model_error_callback(self, *, callback_context, llm_request, error):  # noqa: ANN001
+        await self._emit(
+            "model_error",
+            agent_name=getattr(callback_context, "agent_name", None),
+            error=str(error),
+            **_request_shape(llm_request),
+        )
+        return None
+
+    async def on_event_callback(  # noqa: ANN001
+        self, *, invocation_context: InvocationContext, event: Event
+    ):
+        """Forwards the per-event detail fedotmas's own LoggingPlugin only
+        sends to loguru (tokens, state_delta) — before/after_agent/tool_
+        callback above never see those, so without this the trace tab is
+        blind to them.
+        """
+        if event.partial:
+            return None
+
+        if event.usage_metadata:
+            um = event.usage_metadata
+            prompt = um.prompt_token_count or 0
+            completion = um.candidates_token_count or 0
+            if prompt or completion:
+                await self._emit(
+                    "tokens",
+                    agent_name=event.author,
+                    prompt=prompt,
+                    completion=completion,
+                )
+
+        # The raw text a model turn produced — independent of state_delta
+        # (below), which only shows up when the agent has an `output_key` and
+        # only carries its LAST turn. A mid-pipeline reasoning turn, a worker
+        # with no output_key, or anything before the final answer was
+        # otherwise invisible in the trace even though the model said it.
+        if event.content and event.content.parts:
+            text = "\n".join(
+                part.text for part in event.content.parts if part.text
+            )
+            if text:
+                await self._emit(
+                    "model_response",
+                    agent_name=event.author,
+                    text=_safe_text(text),
+                )
+
+        if event.actions.state_delta:
+            # MAW-style worker agents (see fedotmas.maw.builder) write their
+            # actual output — the EDA report, the tuned pipeline, feature
+            # importances — via `output_key` straight into state, not through
+            # a tool call or the final agent message. Sending only the keys
+            # here (as this used to) hid that content entirely: the trace
+            # showed the agent ran but never what it produced. Values are
+            # truncated the same way every other field is.
+            await self._emit(
+                "state_update",
+                agent_name=event.author,
+                state={k: _safe_text(v) for k, v in event.actions.state_delta.items()},
+            )
+
+        return None

--- a/CoScientist/tools/fedotmas_tools.py
+++ b/CoScientist/tools/fedotmas_tools.py
@@ -1,20 +1,27 @@
 """Tools for fedotmas inference"""
 
 import asyncio
+import uuid
 from typing import List, Optional, Dict, Any
 
 from google.adk.tools import BaseTool, ToolContext
 from google.adk.tools.base_toolset import BaseToolset
 from google.adk.agents.readonly_context import ReadonlyContext
 
-from fedotmas import MAS, HttpMCPServer
+from fedotmas import MAW, HttpMCPServer
+from fedotmas.control import run_config_guardrails
 from fedotmas.plugins import LangfusePlugin, LoggingPlugin, WebSearchLimitPlugin
 
 from CoScientist.tools.fedot_artifact_plugin import ArtifactCapturePlugin
+from CoScientist.tools.fedot_trace_plugin import FedotTracePlugin
+from CoScientist.tools.fedot_trace_handler import fedot_trace_handler
 from CoScientist.logging.metrics import UsageMetricsPlugin
+from CoScientist.logging.fedot_bridge import patch_fedotmas_logging
 from rag_tools import MCPServer
 from rag_tools.storage import PostgresClient
 from rag_tools.config.settings import get_settings
+
+patch_fedotmas_logging()
 
 settings = get_settings()
 
@@ -81,7 +88,7 @@ class FedotMASToolset(BaseToolset):
         # F010.A3/A4: an after_tool_callback plugin captures S3 artifact links
         # (results_presigned_url) at the tool-call boundary, BEFORE FEDOT.MAS sub-agents
         # paraphrase them away / hallucinate molecules.
-        # NB: passing plugins= REPLACES MAS defaults, so re-include them.
+        # NB: passing plugins= REPLACES MAW defaults, so re-include them.
         cap = ArtifactCapturePlugin()
         # NOTE (F015): do NOT impose a short FEDOT timeout — confirm the pipeline produces
         # CORRECT results first, optimize stage latency later. timeout=None = unbounded.
@@ -99,8 +106,10 @@ class FedotMASToolset(BaseToolset):
                 FEDOT_TIMEOUT_S = None
         result = None
         status, err = "success", None
+        run_id = uuid.uuid4().hex
+        await fedot_trace_handler.mark_run_start(run_id, task_description)
         try:
-            mas = MAS(
+            mas = MAW(
                 mcp_servers=servers_payload,
                 # UsageMetricsPlugin bills FEDOT.MAS sub-agents' own LLM traffic
                 # against them, same as any other AgentTool sub-runner — without
@@ -109,15 +118,29 @@ class FedotMASToolset(BaseToolset):
                     LoggingPlugin(),
                     WebSearchLimitPlugin(max_calls_per_agent=4),
                     LangfusePlugin(trace_name="coscientist:fedot"),
+                    FedotTracePlugin(fedot_trace_handler, run_id),
                     cap,
                     UsageMetricsPlugin(),
                 ],
             )
-            result = await mas.run(task_description, timeout=FEDOT_TIMEOUT_S)
+            try:
+                config = await mas.generate_config(task_description)
+                guardrail_errors = run_config_guardrails(config)
+                if guardrail_errors:
+                    raise ValueError(
+                        f"Invalid pipeline config: {'; '.join(guardrail_errors)}"
+                    )
+                result = await mas.build_and_run(
+                    config, task_description, timeout=FEDOT_TIMEOUT_S
+                )
+            finally:
+                mas._finalize_langfuse()
         except (asyncio.TimeoutError, TimeoutError):
             status, err = "timeout", f"FEDOT.MAS exceeded {FEDOT_TIMEOUT_S}s"
         except Exception as e:
             status, err = "error", f"FEDOT.MAS run failed: {e}"
+        finally:
+            await fedot_trace_handler.mark_run_end(run_id, status, err)
 
         # Fallback (F010.A4): scan the final MAS state for presigned URLs the plugin may
         # have missed (only when a result actually came back).

--- a/CoScientist/web/app.py
+++ b/CoScientist/web/app.py
@@ -27,6 +27,7 @@ from CoScientist.web.session_registry import LocalSessionRegistry
 from CoScientist.agents import agent_system, planner_agent
 from CoScientist.config import ReportConfig
 from CoScientist.reporting import finalize_report
+from CoScientist.tools.fedot_trace_handler import fedot_trace_handler
 from CoScientist.hitl.tool import hitl_toolset
 from CoScientist.config import get_settings
 from CoScientist.tools.coder_tools.coder_tools import coder_toolset
@@ -1508,6 +1509,27 @@ def create_app() -> FastAPI:
         except Exception as exc:  # noqa: BLE001 — never crash the server on a UI tail
             print(f"[BuildWS] error ({job_id}): {exc}")
 
+    @app.get("/fedot-trace", response_class=HTMLResponse)
+    async def fedot_trace_page():
+        return HTMLResponse(
+            (WEB_DIR / "templates" / "fedot_trace.html").read_text(encoding="utf-8"),
+            headers={"Cache-Control": "no-store"},
+        )
+
+    @app.websocket("/ws/fedot-trace")
+    async def fedot_trace_ws(ws: WebSocket):
+        """Live feed for the /fedot-trace tab — see fedot_trace_handler.py."""
+        await ws.accept()
+        await ws.send_json({"type": "connected", "run_active": fedot_trace_handler.is_active})
+        await fedot_trace_handler.attach_websocket(ws)
+        try:
+            while True:
+                await ws.receive_text()
+        except WebSocketDisconnect:
+            print("[FedotTraceWS] client disconnected")
+        finally:
+            fedot_trace_handler.detach_websocket(ws)
+
     # --- Roadmap endpoints ---
     @app.get("/api/users/{user_id}/sessions/{session_id}/roadmap")
     async def get_roadmap(user_id: str, session_id: str):
@@ -1628,6 +1650,24 @@ def create_app() -> FastAPI:
             "hierarchy": hierarchy,
             "delegatable_names": list(cfg.delegatable_names()),
         })
+
+    @app.post("/api/fedot-debug-run")
+    async def fedot_debug_run(data: dict):
+        task_description = data.get(
+            "task_description",
+            "Ping test: say hello, do nothing else.",
+        )
+        from CoScientist.tools.fedotmas_tools import FedotMASToolset
+
+        async def _run():
+            toolset = FedotMASToolset()
+            try:
+                await toolset.fedot_tool(task_description=task_description, tool_context=None)
+            except Exception as exc:  # noqa: BLE001 — this is a debug trigger, never crash the server
+                logging.getLogger("CoScientist.web").warning("fedot-debug-run failed: %r", exc)
+
+        asyncio.create_task(_run())
+        return JSONResponse({"status": "started", "task_description": task_description})
 
     # --- Events log ---
     @app.get("/api/users/{user_id}/sessions/{session_id}/events")

--- a/CoScientist/web/static/js/activity_rail.js
+++ b/CoScientist/web/static/js/activity_rail.js
@@ -7,6 +7,7 @@
       { name: "ToolsViewer", icon: "science", desc: "Tools Viewer" },
       { name: "KnowledgeGraph", icon: "bubble_chart", desc: "Knowledge Graph", id: "graph-link", href: "/graph" },
       { name: "MCPBuilds", icon: "build", desc: "MCP Builds", href: "/builds" },
+      { name: "FedotTrace", icon: "monitoring", desc: "FEDOT.MAS Trace", href: "/fedot-trace" },
       { name: "CoderSandbox", icon: "terminal", desc: "CoderSandbox", id: "coder-sandbox-link", href: "http://localhost:8884/" },
       { name: "__settings__", icon: "settings", desc: "Settings" },
     ];
@@ -60,6 +61,8 @@
         }
       } else if (name === "MCPBuilds") {
         window.open('/builds', '_blank');
+      } else if (name === "FedotTrace") {
+        window.open('/fedot-trace', '_blank');
       } else if (name === "CoderSandbox") {
         const link = document.getElementById('coder-sandbox-link');
         const url = (link && link.href) ? link.href : (activeSandboxWatchUrl || getBaseSandboxUrl());

--- a/CoScientist/web/templates/fedot_trace.html
+++ b/CoScientist/web/templates/fedot_trace.html
@@ -1,0 +1,162 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>CoScientist — FEDOT.MAS Trace</title>
+  <style>
+    html, body { margin: 0; height: 100%; background: #1e1e1e; color: #eee;
+                 font-family: -apple-system, Segoe UI, Roboto, sans-serif; }
+    #bar { position: fixed; top: 0; left: 0; right: 0; min-height: 42px; display: flex;
+           align-items: center; gap: 14px; padding: 4px 14px; background: #252526;
+           border-bottom: 1px solid #333; z-index: 10; font-size: 13px; flex-wrap: wrap; }
+    #bar b { color: #fff; }
+    #status { color: #9aa; }
+    #status.connected { color: #2ecc71; }
+    #status.disconnected { color: #e74c3c; }
+    #run-badge { padding: 2px 10px; border-radius: 10px; font-weight: 700; font-size: 11px;
+                 background: #7f8c8d; color: #111; }
+    #run-badge.running { background: #f1c40f; }
+    #run-badge.success { background: #2ecc71; }
+    #run-badge.error, #run-badge.timeout { background: #e74c3c; color: #fff; }
+    button { background: #333; color: #eee; border: 1px solid #444; border-radius: 4px;
+             padding: 4px 10px; cursor: pointer; font-size: 12px; }
+    button:hover { background: #3d3d3d; }
+    label { cursor: pointer; user-select: none; margin-left: auto; }
+
+    #log { position: absolute; top: 50px; bottom: 0; left: 0; right: 0; overflow-y: auto;
+           padding: 10px 16px; font-family: 'JetBrains Mono', ui-monospace, monospace; font-size: 12.5px; }
+    .row { padding: 6px 10px; margin: 4px 0; border-radius: 6px; background: #252526;
+           border-left: 3px solid #444; white-space: pre-wrap; word-break: break-word; }
+    .row .head { display: flex; gap: 8px; align-items: baseline; color: #8ab; margin-bottom: 3px; }
+    .row .time { color: #666; font-size: 11px; }
+    .row .tag { font-weight: 700; text-transform: uppercase; font-size: 10.5px; letter-spacing: .03em; }
+    .row pre { margin: 4px 0 0; color: #ccc; white-space: pre-wrap; word-break: break-word; }
+
+    .row.run_start { border-left-color: #00daf3; background: #17262a; }
+    .row.run_start .tag { color: #00daf3; }
+    .row.run_end.success { border-left-color: #2ecc71; }
+    .row.run_end.success .tag { color: #2ecc71; }
+    .row.run_end.error, .row.run_end.timeout { border-left-color: #e74c3c; background: #2a1717; }
+    .row.run_end.error .tag, .row.run_end.timeout .tag { color: #e74c3c; }
+    .row.agent_start .tag, .row.agent_end .tag { color: #7eb6ff; }
+    .row.tool_start .tag { color: #f6c453; }
+    .row.tool_end .tag { color: #2ecc71; }
+    .row.tool_error .tag, .row.model_error .tag { color: #e74c3c; }
+    .row.tool_error, .row.model_error { border-left-color: #e74c3c; }
+
+    #empty { color: #666; padding: 20px; }
+  </style>
+</head>
+<body>
+  <div id="bar">
+    <b>FEDOT.MAS Trace</b>
+    <span id="status" class="disconnected">connecting…</span>
+    <span id="run-badge">idle</span>
+    <label><input type="checkbox" id="auto-scroll" checked /> auto-scroll</label>
+    <button id="clear">clear</button>
+  </div>
+  <div id="log"><div id="empty">Waiting for FEDOT.MAS activity…</div></div>
+
+  <script>
+    const logEl = document.getElementById("log");
+    const statusEl = document.getElementById("status");
+    const badgeEl = document.getElementById("run-badge");
+    const autoScrollEl = document.getElementById("auto-scroll");
+    const emptyEl = document.getElementById("empty");
+
+    document.getElementById("clear").onclick = () => {
+      logEl.innerHTML = "";
+    };
+
+    function fmtTime(ts) {
+      if (!ts) return "";
+      const d = new Date(ts * 1000);
+      return d.toLocaleTimeString();
+    }
+
+    function setBadge(cls, text) {
+      badgeEl.className = cls;
+      badgeEl.textContent = text;
+    }
+
+    function renderEvent(ev) {
+      if (emptyEl) emptyEl.remove();
+
+      const row = document.createElement("div");
+      row.className = "row " + ev.event + (ev.status ? " " + ev.status : "");
+
+      const head = document.createElement("div");
+      head.className = "head";
+      head.innerHTML =
+        `<span class="time">${fmtTime(ev.timestamp)}</span>` +
+        `<span class="tag">${ev.event.replace(/_/g, " ")}</span>` +
+        `<span>${ev.agent_name || ev.tool_name || ""}</span>`;
+      row.appendChild(head);
+
+      let detail = "";
+      if (ev.event === "run_start") detail = ev.task_description || "";
+      else if (ev.event === "run_end") detail = ev.error || `status: ${ev.status}`;
+      else if (ev.event === "tool_start") detail = ev.tool_args || "";
+      else if (ev.event === "tool_end") detail = ev.result_summary || "";
+      else if (ev.event === "tool_error") detail = ev.error || "";
+      else if (ev.event === "model_error") {
+        const shape = [
+          ev.model && `model: ${ev.model}`,
+          ev.max_output_tokens != null && `max_output_tokens: ${ev.max_output_tokens}`,
+          ev.turns != null && `turns: ${ev.turns}`,
+          ev.prompt_chars != null && `prompt_chars: ${ev.prompt_chars}`,
+        ].filter(Boolean).join("\n");
+        detail = [shape, ev.error || ""].filter(Boolean).join("\n\n");
+      }
+      else if (ev.event === "tokens") detail = `prompt: ${ev.prompt}, completion: ${ev.completion}`;
+      else if (ev.event === "model_response") detail = ev.text || "";
+      else if (ev.event === "state_update" && ev.state) {
+        detail = Object.entries(ev.state).map(([k, v]) => `${k}: ${v}`).join("\n\n");
+      }
+
+      if (detail) {
+        const pre = document.createElement("pre");
+        pre.textContent = detail;
+        row.appendChild(pre);
+      }
+
+      logEl.appendChild(row);
+      if (autoScrollEl.checked) {
+        logEl.scrollTop = logEl.scrollHeight;
+      }
+
+      if (ev.event === "run_start") setBadge("running", "running");
+      else if (ev.event === "run_end") setBadge(ev.status, ev.status);
+    }
+
+    function connect() {
+      const proto = location.protocol === "https:" ? "wss:" : "ws:";
+      const ws = new WebSocket(`${proto}//${location.host}/ws/fedot-trace`);
+
+      ws.onopen = () => {
+        statusEl.textContent = "connected";
+        statusEl.className = "connected";
+      };
+      ws.onclose = () => {
+        statusEl.textContent = "disconnected — retrying…";
+        statusEl.className = "disconnected";
+        setTimeout(connect, 2000);
+      };
+      ws.onerror = () => ws.close();
+
+      ws.onmessage = (msg) => {
+        const data = JSON.parse(msg.data);
+        if (data.type === "connected") {
+          if (data.run_active) setBadge("running", "running");
+          return;
+        }
+        if (data.type === "fedot_trace_event") {
+          renderEvent(data);
+        }
+      };
+    }
+
+    connect();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
Пробрасывает loguru-логи fedotmas в стандартный logging приложения и добавляет живой просмотр трассировки запусков FEDOT.MAS.

fedot_bridge.py - подменяет логуру синк на свой, который перенаправляет записи в logging.getLogger логи FEDOT MAS теперь попадают туда же и в том же формате, что и остальные логи приложения
Вызывается один раз при импорте fedotmas_tools.py