### PR TITLE
Fix: bound every S3 call, and refuse to start without S3 config

### DIFF
--- a/CoScientist/paper_parser/s3_connection.py
+++ b/CoScientist/paper_parser/s3_connection.py
@@ -8,6 +8,23 @@ from botocore.client import Config
 from dotenv import load_dotenv, find_dotenv
 load_dotenv(find_dotenv())
 
+# Bounds for one S3 call. The defaults are 60 s to connect, 60 s to read, and up
+# to 5 attempts, so an endpoint that drops packets blocks the caller for about
+# 300 s. An MCP tool runs inside that call, and the ADK client gives up at 300 s.
+# The client then closes the stream, and the server logs a ClosedResourceError
+# for a response nobody waits for. Fail in seconds instead, so the tool returns
+# an error the agent can read.
+_CONNECT_TIMEOUT_SECONDS = 5
+_READ_TIMEOUT_SECONDS = 30
+_MAX_ATTEMPTS = 3
+
+_CLIENT_CONFIG = Config(
+    signature_version="s3v4",
+    connect_timeout=_CONNECT_TIMEOUT_SECONDS,
+    read_timeout=_READ_TIMEOUT_SECONDS,
+    retries={"max_attempts": _MAX_ATTEMPTS, "mode": "standard"},
+)
+
 
 class S3BucketService:
     """
@@ -55,7 +72,7 @@ class S3BucketService:
             endpoint_url=self.endpoint,
             aws_access_key_id=self.access_key,
             aws_secret_access_key=self.secret_key,
-            config=Config(signature_version="s3v4"),
+            config=_CLIENT_CONFIG,
         )
         return client
     

--- a/mcp-servers/chemical-mcp-server/server/chemical_server.py
+++ b/mcp-servers/chemical-mcp-server/server/chemical_server.py
@@ -600,9 +600,44 @@ def forward_predict(
     result["metadata"] = metadata
     return result
 
+# Every tool that makes a figure, a table or a CSV stores it in S3. Without this
+# configuration the server starts, accepts a call, and then fails inside boto3.
+_REQUIRED_S3_SETTINGS = (
+    ("S3__ENDPOINT_URL", "s3_endpoint_url"),
+    ("S3__BUCKET_NAME", "s3_bucket_name"),
+    ("S3__ACCESS_KEY", "s3_access_key"),
+    ("S3__SECRET_KEY", "s3_secret_key"),
+)
+
+
+def _check_s3_settings(settings) -> None:
+    """Stop the server when the S3 configuration is incomplete.
+
+    A missing endpoint sends boto3 to the real AWS endpoint of the bucket name.
+    On a host without that egress the call blocks until the retries run out. The
+    tool returns nothing, the file reaches no bucket, and the log shows only the
+    stream teardown that follows. Refuse to start instead.
+    """
+    missing = [name for name, attr in _REQUIRED_S3_SETTINGS if not getattr(settings, attr)]
+    if missing:
+        raise SystemExit(
+            "chemical-mcp-server: missing S3 configuration: "
+            + ", ".join(missing)
+            + ". Set these in the env_file of the service. Two compose files"
+            " start this server, and they read different files:"
+            " mcp-servers/docker-compose.yml reads mcp-servers/.env, and"
+            " mcp-servers/chemical-mcp-server/docker-compose.yml reads"
+            " mcp-servers/chemical-mcp-server/.env."
+        )
+
+
 def main() -> None:
     """Entry point for the MCP server."""
     settings = get_settings()
+    _check_s3_settings(settings)
+    logger.info(
+        "S3 endpoint %s, bucket %s", settings.s3_endpoint_url, settings.s3_bucket_name,
+    )
     mcp.run(
         transport="http",
         host=settings.chem_mcp_host,

--- a/mcp-servers/chemical-mcp-server/server/utils/vault.py
+++ b/mcp-servers/chemical-mcp-server/server/utils/vault.py
@@ -41,8 +41,18 @@ def scoped_prefix(user_id: str | None, session_id: str | None, feature: str) -> 
 
 def contract(s3_key: str) -> dict:
     """The return contract for one stored object."""
+    bucket = s3_service.bucket_name
+    if not bucket:
+        # Every consumer needs the pair. CoScientist.utils.s3_refs drops a record
+        # that carries a key and no bucket, because a key alone does not say where
+        # the object is. main() refuses to start without a bucket name, so this is
+        # the second line of defense, for an s3_service built some other way.
+        raise RuntimeError(
+            "S3 bucket name is not configured, so the object at "
+            f"{s3_key} has no durable reference. Set S3__BUCKET_NAME."
+        )
     return {
-        "bucket": s3_service.bucket_name,
+        "bucket": bucket,
         "s3_key": s3_key,
         "presigned_url": s3_service.generate_presigned_url(
             s3_key, expiration=_URL_TTL_SECONDS

--- a/mcp-servers/vault-mcp-server/vault_server.py
+++ b/mcp-servers/vault-mcp-server/vault_server.py
@@ -30,7 +30,17 @@ VAULT_SURFACE = os.environ.get('VAULT_SURFACE', 'all').lower()
 if VAULT_SURFACE not in ('worker', 'framework', 'all'):
     raise ValueError(f"VAULT_SURFACE must be worker, framework or all, got '{VAULT_SURFACE}'")
 
-_client_config = Config(signature_version='s3v4', s3={'addressing_style': 'path'})
+# Bounds for one S3 call. The botocore defaults are 60 s to connect, 60 s to
+# read, and up to 5 attempts, so an endpoint that drops packets blocks a tool
+# for about 300 s. The MCP client gives up at 300 s and closes the stream, and
+# the server then logs a ClosedResourceError for a response nobody waits for.
+_client_config = Config(
+    signature_version='s3v4',
+    s3={'addressing_style': 'path'},
+    connect_timeout=5,
+    read_timeout=30,
+    retries={'max_attempts': 3, 'mode': 'standard'},
+)
 
 # Internal client for direct operations.
 s3_client = boto3.client(


### PR DESCRIPTION
# Fix: bound every S3 call, and refuse to start without S3 config

Branch: `fix/s3-client-timeouts` → `main`

## Summary

The chemical MCP server logs `anyio.ClosedResourceError`, and the files it makes
reach no bucket. One unbounded S3 call causes both. This branch bounds the call
and makes a missing S3 configuration visible at startup.

## The problem

`S3BucketService.create_s3_client` built the boto3 client with
`Config(signature_version="s3v4")` and nothing else. The botocore defaults are
60 s to connect, 60 s to read, and up to 5 attempts. An endpoint that drops
packets therefore blocks the caller for about 300 s.

`DynamicMCPToolset` sets `sse_read_timeout` to 300 s. So the client gives up
first and closes the stream. The server then writes its response into a stream
that is already closed, and the MCP transport raises. The log shows only that
teardown:

```
anyio.ClosedResourceError
RuntimeError: Unexpected ASGI message 'http.response.start' sent, after response
already completed.
```

Neither line names the upload that hung. The tool returns nothing, so the file
exists nowhere.

The most common trigger is an empty `S3__ENDPOINT_URL`. boto3 then falls back to
the real AWS endpoint of the bucket name. A host without that egress blackholes
the request, and the retries run out at about 300 s.

## Changes

**Bound the S3 clients.** `CoScientist/paper_parser/s3_connection.py` and both
clients in `mcp-servers/vault-mcp-server/vault_server.py` now use 5 s to
connect, 30 s to read, and 3 attempts. A bad endpoint fails in seconds. The tool
returns an error that the agent can read, and the MCP session stays open.
`read_timeout` applies to one socket read, so a large transfer still completes.

**Fail fast on missing configuration.** `main()` in the chemical server checks
the four `S3__*` settings and stops when one is empty. The message names both
compose files, because they read different env files:

- `mcp-servers/docker-compose.yml` reads `mcp-servers/.env`
- `mcp-servers/chemical-mcp-server/docker-compose.yml` reads
  `mcp-servers/chemical-mcp-server/.env`

**Log the target at startup.** The server prints the endpoint and the bucket, so
one line of the log answers where the files go.

**Never return a bucket of `None`.** `vault.contract()` raises instead.
`CoScientist/utils/s3_refs` drops a record that has a key and no bucket, because
a key alone does not say where the object is. Such an artifact used to disappear
from the execution graph, the artifact index, and the report, without a message.

## Scope

- `CoScientist/paper_parser/s3_connection.py` — timeouts and a retry cap on the
  shared client. The papers-search, dataset-collection, and chemical images all
  copy this file.
- `mcp-servers/vault-mcp-server/vault_server.py` — the same bounds on the
  internal client and the signing client.
- `mcp-servers/chemical-mcp-server/server/chemical_server.py` —
  `_check_s3_settings()` in `main()`, and a startup log line.
- `mcp-servers/chemical-mcp-server/server/utils/vault.py` — `contract()` raises
  when the bucket name is empty.

## Deployment note

This branch sets the S3 configuration of no host. It only makes a missing
configuration visible.

Both compose files use `restart: unless-stopped`. A host that lacks `S3__*` will
crash-loop after this change, and `DynamicMCPToolset.get_tools` skips an
unreachable server without a message. Every chemical tool then disappears from
the agent, including the tools that never touch S3.

Check the env file of the host before you deploy, or apply the configuration and
this change in the same restart.

## Test

`tests/unit/test_s3_refs.py` and `tests/unit/test_session_scope_plugin.py` pass.
32 tests.

No test covers the timeout values. They are configuration, and a test for them
would assert the botocore API rather than our behavior.